### PR TITLE
Start in on pathway definitions.

### DIFF
--- a/causal_pathways/bench_achievement.json
+++ b/causal_pathways/bench_achievement.json
@@ -1,0 +1,58 @@
+{
+  "@context": {
+    "@vocab": "http://schema.org/",
+    "cpo": "http://example.com/cpo#",
+    "cpo:CausalPathway":     "http://purl.obolibrary.org/obo/cpo_0000029",
+    "cpo:PreventionFraming": "http://example.com/cpo#cpo_0000038",
+    "cpo:PromotionFraming":  "http://example.com/cpo#cpo_0000037",
+    "cpo:PreventionFocus":   "http://example.com/cpo#cpo_0000036",
+    "cpo:Promotion_focus":   "http://example.com/cpo#cpo_0000035",
+    "cpo:Mechanism":         "http://example.com/cpo#cpo_0000001",
+    "cpo:Moderator":         "http://example.com/cpo#cpo_0000005",
+    "cpo:ProximalOutcome":   "http://example.com/cpo#cpo_0000006",
+    "cpo:DistalOutcome":     "http://example.com/cpo#cpo_0000007",
+    "slowmo": "http://example.com/slowmo#",
+    "slowmo:PerformanceGapPositive":   "http://example.com/slowmo#PerformanceGapPositive",
+    "slowmo:PerformanceGapNegative":   "http://example.com/slowmo#PerformanceGapNegative",
+    "slowmo:PerformanceTrendPositive": "http://example.com/slowmo#PerformanceTrendPositive",
+    "slowmo:PerformanceTrendNegative": "http://example.com/slowmo#PerformanceTrendNegative",
+    "slowmo:NormativeComparator":      "http://example.com/slowmo#NormativeComparator",
+    "slowmo:PerformanceGapSize":       "http://example.com/slowmo#PerformanceGapSize",
+    "slowmo:HasPrecondition":   "http://example.com/slowmo#HasPrecondition",
+    "slowmo:HasModerator":      "http://example.com/slowmo#HasModerator",
+    "slowmo:ModeratorScore":    "http://example.com/slowmo#ModeratorScore",
+    "slowmo:Habituation":       "http://example.com/slowmo#Habituation",
+    "slowmo:RegulatoryFit":     "http://example.com/slowmo#RegulatoryFit",
+    "slowmo:SelfEfficacy":      "http://example.com/slowmo#SelfEfficacy",
+    "slowmo:Achievement":       "http://example.com/slowmo#Achievement",
+    "slowmo:Habituation":       "http://example.com/slowmo#Habituation"
+  },
+
+  "@graph": [
+    {
+      "@id": "http://example.com/slomo#BenchAchievement",
+      "@type": "http://purl.obolibrary.org/obo/cpo_0000029",
+      "name": "Bench Achievement",
+
+      "cpo:HasPrecondition":[
+        "http://example.com/slowmo#Achievement", 
+        "http://example.com/slowmo#NormativeComparator"
+      ],
+
+      "slowmo:HasModerator":[
+        {"@type": "http://example.com/slowmo#Habituation",
+          "slowmo:ModeratorScore": 100
+        },
+        {"@type": "http://example.com/slowmo#RegulatoryFit",
+          "slowmo:ModeratorScore": 10
+        }
+      ],
+
+      "slowmo:ImplementationStrategy": "show benchmark high performance",
+      "cpo:Mechanism": "beliefs about capability",
+      "cpo:ProximalOutcome": [ "engagement", "acceptibility", "appropriateness"],
+      "cpo:DistalOutcome": [ "maintain effort", "clinical practice is maintained"],
+      "slomo:KeyMessage": "You reached the benchmark this month."
+    }
+  ]
+}

--- a/causal_pathways/bench_diff.json
+++ b/causal_pathways/bench_diff.json
@@ -1,0 +1,59 @@
+{
+  "@context": {
+    "@vocab": "http://schema.org/",
+    "cpo": "http://example.com/cpo#",
+    "cpo:CausalPathway":     "http://purl.obolibrary.org/obo/cpo_0000029",
+    "cpo:PreventionFraming": "http://example.com/cpo#cpo_0000038",
+    "cpo:PromotionFraming":  "http://example.com/cpo#cpo_0000037",
+    "cpo:PreventionFocus":   "http://example.com/cpo#cpo_0000036",
+    "cpo:Promotion_focus":   "http://example.com/cpo#cpo_0000035",
+    "cpo:Mechanism":         "http://example.com/cpo#cpo_0000001",
+    "cpo:Moderator":         "http://example.com/cpo#cpo_0000005",
+    "cpo:ProximalOutcome":   "http://example.com/cpo#cpo_0000006",
+    "cpo:DistalOutcome":     "http://example.com/cpo#cpo_0000007",
+    "slowmo": "http://example.com/slowmo#",
+    "slowmo:PerformanceGapPositive":   "http://example.com/slowmo#PerformanceGapPositive",
+    "slowmo:PerformanceGapNegative":   "http://example.com/slowmo#PerformanceGapNegative",
+    "slowmo:PerformanceTrendPositive": "http://example.com/slowmo#PerformanceTrendPositive",
+    "slowmo:PerformanceTrendNegative": "http://example.com/slowmo#PerformanceTrendNegative",
+    "slowmo:NormativeComparator":      "http://example.com/slowmo#NormativeComparator",
+    "slowmo:PerformanceGapSize":       "http://example.com/slowmo#PerformanceGapSize",
+    "slowmo:HasPrecondition":   "http://example.com/slowmo#HasPrecondition",
+    "slowmo:HasModerator":      "http://example.com/slowmo#HasModerator",
+    "slowmo:ModeratorScore":    "http://example.com/slowmo#ModeratorScore",
+    "slowmo:Habituation":       "http://example.com/slowmo#Habituation",
+    "slowmo:RegulatoryFit":     "http://example.com/slowmo#RegulatoryFit",
+    "slowmo:SelfEfficacy":      "http://example.com/slowmo#SelfEfficacy",
+    "slowmo:Achievement":       "http://example.com/slowmo#Achievement",
+    "slowmo:Habituation":       "http://example.com/slowmo#Habituation"
+  },
+
+  "@graph": [
+    {
+      "@id": "",
+      "@type": "http://purl.obolibrary.org/obo/cpo_0000029",
+      "name": "",
+
+      "cpo:HasPrecondition":[ 
+        ""
+      ],
+
+      "slowmo:HasModerator":[
+        {"@type": "",
+          "slowmo:ModeratorScore": 100
+        },
+        {"@type": "",
+          "slowmo:ModeratorScore": 100
+        }
+      ],
+
+      "slowmo:ImplementationStrategy": "",
+      "cpo:Mechanism": "",
+      "cpo:ProximalOutcome": ["engagement", "acceptibility", "appropriateness"],
+      "cpo:DistalOutcome": [ 
+        "", 
+        "clinical practice is maintained"],
+      "slomo:KeyMessage": ""
+    }
+  ]
+}

--- a/causal_pathways/consistent_high.json
+++ b/causal_pathways/consistent_high.json
@@ -1,0 +1,59 @@
+{
+  "@context": {
+    "@vocab": "http://schema.org/",
+    "cpo": "http://example.com/cpo#",
+    "cpo:CausalPathway":     "http://purl.obolibrary.org/obo/cpo_0000029",
+    "cpo:PreventionFraming": "http://example.com/cpo#cpo_0000038",
+    "cpo:PromotionFraming":  "http://example.com/cpo#cpo_0000037",
+    "cpo:PreventionFocus":   "http://example.com/cpo#cpo_0000036",
+    "cpo:Promotion_focus":   "http://example.com/cpo#cpo_0000035",
+    "cpo:Mechanism":         "http://example.com/cpo#cpo_0000001",
+    "cpo:Moderator":         "http://example.com/cpo#cpo_0000005",
+    "cpo:ProximalOutcome":   "http://example.com/cpo#cpo_0000006",
+    "cpo:DistalOutcome":     "http://example.com/cpo#cpo_0000007",
+    "slowmo": "http://example.com/slowmo#",
+    "slowmo:PerformanceGapPositive":   "http://example.com/slowmo#PerformanceGapPositive",
+    "slowmo:PerformanceGapNegative":   "http://example.com/slowmo#PerformanceGapNegative",
+    "slowmo:PerformanceTrendPositive": "http://example.com/slowmo#PerformanceTrendPositive",
+    "slowmo:PerformanceTrendNegative": "http://example.com/slowmo#PerformanceTrendNegative",
+    "slowmo:NormativeComparator":      "http://example.com/slowmo#NormativeComparator",
+    "slowmo:PerformanceGapSize":       "http://example.com/slowmo#PerformanceGapSize",
+    "slowmo:HasPrecondition":   "http://example.com/slowmo#HasPrecondition",
+    "slowmo:HasModerator":      "http://example.com/slowmo#HasModerator",
+    "slowmo:ModeratorScore":    "http://example.com/slowmo#ModeratorScore",
+    "slowmo:Habituation":       "http://example.com/slowmo#Habituation",
+    "slowmo:RegulatoryFit":     "http://example.com/slowmo#RegulatoryFit",
+    "slowmo:SelfEfficacy":      "http://example.com/slowmo#SelfEfficacy",
+    "slowmo:Achievement":       "http://example.com/slowmo#Achievement",
+    "slowmo:Habituation":       "http://example.com/slowmo#Habituation"
+  },
+
+  "@graph": [
+    {
+      "@id": "",
+      "@type": "http://purl.obolibrary.org/obo/cpo_0000029",
+      "name": "",
+
+      "cpo:HasPrecondition":[ 
+        ""
+      ],
+
+      "slowmo:HasModerator":[
+        {"@type": "",
+          "slowmo:ModeratorScore": 100
+        },
+        {"@type": "",
+          "slowmo:ModeratorScore": 100
+        }
+      ],
+
+      "slowmo:ImplementationStrategy": "",
+      "cpo:Mechanism": "",
+      "cpo:ProximalOutcome": ["engagement", "acceptibility", "appropriateness"],
+      "cpo:DistalOutcome": [ 
+        "", 
+        "clinical practice is maintained"],
+      "slomo:KeyMessage": ""
+    }
+  ]
+}

--- a/causal_pathways/consistent_low.json
+++ b/causal_pathways/consistent_low.json
@@ -1,0 +1,59 @@
+{
+  "@context": {
+    "@vocab": "http://schema.org/",
+    "cpo": "http://example.com/cpo#",
+    "cpo:CausalPathway":     "http://purl.obolibrary.org/obo/cpo_0000029",
+    "cpo:PreventionFraming": "http://example.com/cpo#cpo_0000038",
+    "cpo:PromotionFraming":  "http://example.com/cpo#cpo_0000037",
+    "cpo:PreventionFocus":   "http://example.com/cpo#cpo_0000036",
+    "cpo:Promotion_focus":   "http://example.com/cpo#cpo_0000035",
+    "cpo:Mechanism":         "http://example.com/cpo#cpo_0000001",
+    "cpo:Moderator":         "http://example.com/cpo#cpo_0000005",
+    "cpo:ProximalOutcome":   "http://example.com/cpo#cpo_0000006",
+    "cpo:DistalOutcome":     "http://example.com/cpo#cpo_0000007",
+    "slowmo": "http://example.com/slowmo#",
+    "slowmo:PerformanceGapPositive":   "http://example.com/slowmo#PerformanceGapPositive",
+    "slowmo:PerformanceGapNegative":   "http://example.com/slowmo#PerformanceGapNegative",
+    "slowmo:PerformanceTrendPositive": "http://example.com/slowmo#PerformanceTrendPositive",
+    "slowmo:PerformanceTrendNegative": "http://example.com/slowmo#PerformanceTrendNegative",
+    "slowmo:NormativeComparator":      "http://example.com/slowmo#NormativeComparator",
+    "slowmo:PerformanceGapSize":       "http://example.com/slowmo#PerformanceGapSize",
+    "slowmo:HasPrecondition":   "http://example.com/slowmo#HasPrecondition",
+    "slowmo:HasModerator":      "http://example.com/slowmo#HasModerator",
+    "slowmo:ModeratorScore":    "http://example.com/slowmo#ModeratorScore",
+    "slowmo:Habituation":       "http://example.com/slowmo#Habituation",
+    "slowmo:RegulatoryFit":     "http://example.com/slowmo#RegulatoryFit",
+    "slowmo:SelfEfficacy":      "http://example.com/slowmo#SelfEfficacy",
+    "slowmo:Achievement":       "http://example.com/slowmo#Achievement",
+    "slowmo:Habituation":       "http://example.com/slowmo#Habituation"
+  },
+
+  "@graph": [
+    {
+      "@id": "",
+      "@type": "http://purl.obolibrary.org/obo/cpo_0000029",
+      "name": "",
+
+      "cpo:HasPrecondition":[ 
+        ""
+      ],
+
+      "slowmo:HasModerator":[
+        {"@type": "",
+          "slowmo:ModeratorScore": 100
+        },
+        {"@type": "",
+          "slowmo:ModeratorScore": 100
+        }
+      ],
+
+      "slowmo:ImplementationStrategy": "",
+      "cpo:Mechanism": "",
+      "cpo:ProximalOutcome": ["engagement", "acceptibility", "appropriateness"],
+      "cpo:DistalOutcome": [ 
+        "", 
+        "clinical practice is maintained"],
+      "slomo:KeyMessage": ""
+    }
+  ]
+}

--- a/causal_pathways/goal_achievement.json
+++ b/causal_pathways/goal_achievement.json
@@ -1,0 +1,59 @@
+{
+  "@context": {
+    "@vocab": "http://schema.org/",
+    "cpo": "http://example.com/cpo#",
+    "cpo:CausalPathway":     "http://purl.obolibrary.org/obo/cpo_0000029",
+    "cpo:PreventionFraming": "http://example.com/cpo#cpo_0000038",
+    "cpo:PromotionFraming":  "http://example.com/cpo#cpo_0000037",
+    "cpo:PreventionFocus":   "http://example.com/cpo#cpo_0000036",
+    "cpo:Promotion_focus":   "http://example.com/cpo#cpo_0000035",
+    "cpo:Mechanism":         "http://example.com/cpo#cpo_0000001",
+    "cpo:Moderator":         "http://example.com/cpo#cpo_0000005",
+    "cpo:ProximalOutcome":   "http://example.com/cpo#cpo_0000006",
+    "cpo:DistalOutcome":     "http://example.com/cpo#cpo_0000007",
+    "slowmo": "http://example.com/slowmo#",
+    "slowmo:PerformanceGapPositive":   "http://example.com/slowmo#PerformanceGapPositive",
+    "slowmo:PerformanceGapNegative":   "http://example.com/slowmo#PerformanceGapNegative",
+    "slowmo:PerformanceTrendPositive": "http://example.com/slowmo#PerformanceTrendPositive",
+    "slowmo:PerformanceTrendNegative": "http://example.com/slowmo#PerformanceTrendNegative",
+    "slowmo:NormativeComparator":      "http://example.com/slowmo#NormativeComparator",
+    "slowmo:PerformanceGapSize":       "http://example.com/slowmo#PerformanceGapSize",
+    "slowmo:HasPrecondition":   "http://example.com/slowmo#HasPrecondition",
+    "slowmo:HasModerator":      "http://example.com/slowmo#HasModerator",
+    "slowmo:ModeratorScore":    "http://example.com/slowmo#ModeratorScore",
+    "slowmo:Habituation":       "http://example.com/slowmo#Habituation",
+    "slowmo:RegulatoryFit":     "http://example.com/slowmo#RegulatoryFit",
+    "slowmo:SelfEfficacy":      "http://example.com/slowmo#SelfEfficacy",
+    "slowmo:Achievement":       "http://example.com/slowmo#Achievement",
+    "slowmo:Habituation":       "http://example.com/slowmo#Habituation"
+  },
+
+  "@graph": [
+    {
+      "@id": "",
+      "@type": "http://purl.obolibrary.org/obo/cpo_0000029",
+      "name": "",
+
+      "cpo:HasPrecondition":[ 
+        ""
+      ],
+
+      "slowmo:HasModerator":[
+        {"@type": "",
+          "slowmo:ModeratorScore": 100
+        },
+        {"@type": "",
+          "slowmo:ModeratorScore": 100
+        }
+      ],
+
+      "slowmo:ImplementationStrategy": "",
+      "cpo:Mechanism": "",
+      "cpo:ProximalOutcome": ["engagement", "acceptibility", "appropriateness"],
+      "cpo:DistalOutcome": [ 
+        "", 
+        "clinical practice is maintained"],
+      "slomo:KeyMessage": ""
+    }
+  ]
+}

--- a/causal_pathways/goal_diff.json
+++ b/causal_pathways/goal_diff.json
@@ -1,0 +1,59 @@
+{
+  "@context": {
+    "@vocab": "http://schema.org/",
+    "cpo": "http://example.com/cpo#",
+    "cpo:CausalPathway":     "http://purl.obolibrary.org/obo/cpo_0000029",
+    "cpo:PreventionFraming": "http://example.com/cpo#cpo_0000038",
+    "cpo:PromotionFraming":  "http://example.com/cpo#cpo_0000037",
+    "cpo:PreventionFocus":   "http://example.com/cpo#cpo_0000036",
+    "cpo:Promotion_focus":   "http://example.com/cpo#cpo_0000035",
+    "cpo:Mechanism":         "http://example.com/cpo#cpo_0000001",
+    "cpo:Moderator":         "http://example.com/cpo#cpo_0000005",
+    "cpo:ProximalOutcome":   "http://example.com/cpo#cpo_0000006",
+    "cpo:DistalOutcome":     "http://example.com/cpo#cpo_0000007",
+    "slowmo": "http://example.com/slowmo#",
+    "slowmo:PerformanceGapPositive":   "http://example.com/slowmo#PerformanceGapPositive",
+    "slowmo:PerformanceGapNegative":   "http://example.com/slowmo#PerformanceGapNegative",
+    "slowmo:PerformanceTrendPositive": "http://example.com/slowmo#PerformanceTrendPositive",
+    "slowmo:PerformanceTrendNegative": "http://example.com/slowmo#PerformanceTrendNegative",
+    "slowmo:NormativeComparator":      "http://example.com/slowmo#NormativeComparator",
+    "slowmo:PerformanceGapSize":       "http://example.com/slowmo#PerformanceGapSize",
+    "slowmo:HasPrecondition":   "http://example.com/slowmo#HasPrecondition",
+    "slowmo:HasModerator":      "http://example.com/slowmo#HasModerator",
+    "slowmo:ModeratorScore":    "http://example.com/slowmo#ModeratorScore",
+    "slowmo:Habituation":       "http://example.com/slowmo#Habituation",
+    "slowmo:RegulatoryFit":     "http://example.com/slowmo#RegulatoryFit",
+    "slowmo:SelfEfficacy":      "http://example.com/slowmo#SelfEfficacy",
+    "slowmo:Achievement":       "http://example.com/slowmo#Achievement",
+    "slowmo:Habituation":       "http://example.com/slowmo#Habituation"
+  },
+
+  "@graph": [
+    {
+      "@id": "",
+      "@type": "http://purl.obolibrary.org/obo/cpo_0000029",
+      "name": "",
+
+      "cpo:HasPrecondition":[ 
+        ""
+      ],
+
+      "slowmo:HasModerator":[
+        {"@type": "",
+          "slowmo:ModeratorScore": 100
+        },
+        {"@type": "",
+          "slowmo:ModeratorScore": 100
+        }
+      ],
+
+      "slowmo:ImplementationStrategy": "",
+      "cpo:Mechanism": "",
+      "cpo:ProximalOutcome": ["engagement", "acceptibility", "appropriateness"],
+      "cpo:DistalOutcome": [ 
+        "", 
+        "clinical practice is maintained"],
+      "slomo:KeyMessage": ""
+    }
+  ]
+}

--- a/causal_pathways/high_bench.json
+++ b/causal_pathways/high_bench.json
@@ -1,0 +1,59 @@
+{
+  "@context": {
+    "@vocab": "http://schema.org/",
+    "cpo": "http://example.com/cpo#",
+    "cpo:CausalPathway":     "http://purl.obolibrary.org/obo/cpo_0000029",
+    "cpo:PreventionFraming": "http://example.com/cpo#cpo_0000038",
+    "cpo:PromotionFraming":  "http://example.com/cpo#cpo_0000037",
+    "cpo:PreventionFocus":   "http://example.com/cpo#cpo_0000036",
+    "cpo:Promotion_focus":   "http://example.com/cpo#cpo_0000035",
+    "cpo:Mechanism":         "http://example.com/cpo#cpo_0000001",
+    "cpo:Moderator":         "http://example.com/cpo#cpo_0000005",
+    "cpo:ProximalOutcome":   "http://example.com/cpo#cpo_0000006",
+    "cpo:DistalOutcome":     "http://example.com/cpo#cpo_0000007",
+    "slowmo": "http://example.com/slowmo#",
+    "slowmo:PerformanceGapPositive":   "http://example.com/slowmo#PerformanceGapPositive",
+    "slowmo:PerformanceGapNegative":   "http://example.com/slowmo#PerformanceGapNegative",
+    "slowmo:PerformanceTrendPositive": "http://example.com/slowmo#PerformanceTrendPositive",
+    "slowmo:PerformanceTrendNegative": "http://example.com/slowmo#PerformanceTrendNegative",
+    "slowmo:NormativeComparator":      "http://example.com/slowmo#NormativeComparator",
+    "slowmo:PerformanceGapSize":       "http://example.com/slowmo#PerformanceGapSize",
+    "slowmo:HasPrecondition":   "http://example.com/slowmo#HasPrecondition",
+    "slowmo:HasModerator":      "http://example.com/slowmo#HasModerator",
+    "slowmo:ModeratorScore":    "http://example.com/slowmo#ModeratorScore",
+    "slowmo:Habituation":       "http://example.com/slowmo#Habituation",
+    "slowmo:RegulatoryFit":     "http://example.com/slowmo#RegulatoryFit",
+    "slowmo:SelfEfficacy":      "http://example.com/slowmo#SelfEfficacy",
+    "slowmo:Achievement":       "http://example.com/slowmo#Achievement",
+    "slowmo:Habituation":       "http://example.com/slowmo#Habituation"
+  },
+
+  "@graph": [
+    {
+      "@id": "",
+      "@type": "http://purl.obolibrary.org/obo/cpo_0000029",
+      "name": "",
+
+      "cpo:HasPrecondition":[ 
+        ""
+      ],
+
+      "slowmo:HasModerator":[
+        {"@type": "",
+          "slowmo:ModeratorScore": 100
+        },
+        {"@type": "",
+          "slowmo:ModeratorScore": 100
+        }
+      ],
+
+      "slowmo:ImplementationStrategy": "",
+      "cpo:Mechanism": "",
+      "cpo:ProximalOutcome": ["engagement", "acceptibility", "appropriateness"],
+      "cpo:DistalOutcome": [ 
+        "", 
+        "clinical practice is maintained"],
+      "slomo:KeyMessage": ""
+    }
+  ]
+}

--- a/causal_pathways/negative_trend.json
+++ b/causal_pathways/negative_trend.json
@@ -1,0 +1,59 @@
+{
+  "@context": {
+    "@vocab": "http://schema.org/",
+    "cpo": "http://example.com/cpo#",
+    "cpo:CausalPathway":     "http://purl.obolibrary.org/obo/cpo_0000029",
+    "cpo:PreventionFraming": "http://example.com/cpo#cpo_0000038",
+    "cpo:PromotionFraming":  "http://example.com/cpo#cpo_0000037",
+    "cpo:PreventionFocus":   "http://example.com/cpo#cpo_0000036",
+    "cpo:Promotion_focus":   "http://example.com/cpo#cpo_0000035",
+    "cpo:Mechanism":         "http://example.com/cpo#cpo_0000001",
+    "cpo:Moderator":         "http://example.com/cpo#cpo_0000005",
+    "cpo:ProximalOutcome":   "http://example.com/cpo#cpo_0000006",
+    "cpo:DistalOutcome":     "http://example.com/cpo#cpo_0000007",
+    "slowmo": "http://example.com/slowmo#",
+    "slowmo:PerformanceGapPositive":   "http://example.com/slowmo#PerformanceGapPositive",
+    "slowmo:PerformanceGapNegative":   "http://example.com/slowmo#PerformanceGapNegative",
+    "slowmo:PerformanceTrendPositive": "http://example.com/slowmo#PerformanceTrendPositive",
+    "slowmo:PerformanceTrendNegative": "http://example.com/slowmo#PerformanceTrendNegative",
+    "slowmo:NormativeComparator":      "http://example.com/slowmo#NormativeComparator",
+    "slowmo:PerformanceGapSize":       "http://example.com/slowmo#PerformanceGapSize",
+    "slowmo:HasPrecondition":   "http://example.com/slowmo#HasPrecondition",
+    "slowmo:HasModerator":      "http://example.com/slowmo#HasModerator",
+    "slowmo:ModeratorScore":    "http://example.com/slowmo#ModeratorScore",
+    "slowmo:Habituation":       "http://example.com/slowmo#Habituation",
+    "slowmo:RegulatoryFit":     "http://example.com/slowmo#RegulatoryFit",
+    "slowmo:SelfEfficacy":      "http://example.com/slowmo#SelfEfficacy",
+    "slowmo:Achievement":       "http://example.com/slowmo#Achievement",
+    "slowmo:Habituation":       "http://example.com/slowmo#Habituation"
+  },
+
+  "@graph": [
+    {
+      "@id": "",
+      "@type": "http://purl.obolibrary.org/obo/cpo_0000029",
+      "name": "",
+
+      "cpo:HasPrecondition":[ 
+        ""
+      ],
+
+      "slowmo:HasModerator":[
+        {"@type": "",
+          "slowmo:ModeratorScore": 100
+        },
+        {"@type": "",
+          "slowmo:ModeratorScore": 100
+        }
+      ],
+
+      "slowmo:ImplementationStrategy": "",
+      "cpo:Mechanism": "",
+      "cpo:ProximalOutcome": ["engagement", "acceptibility", "appropriateness"],
+      "cpo:DistalOutcome": [ 
+        "", 
+        "clinical practice is maintained"],
+      "slomo:KeyMessage": ""
+    }
+  ]
+}

--- a/causal_pathways/positive_trend.json
+++ b/causal_pathways/positive_trend.json
@@ -1,0 +1,59 @@
+{
+  "@context": {
+    "@vocab": "http://schema.org/",
+    "cpo": "http://example.com/cpo#",
+    "cpo:CausalPathway":     "http://purl.obolibrary.org/obo/cpo_0000029",
+    "cpo:PreventionFraming": "http://example.com/cpo#cpo_0000038",
+    "cpo:PromotionFraming":  "http://example.com/cpo#cpo_0000037",
+    "cpo:PreventionFocus":   "http://example.com/cpo#cpo_0000036",
+    "cpo:Promotion_focus":   "http://example.com/cpo#cpo_0000035",
+    "cpo:Mechanism":         "http://example.com/cpo#cpo_0000001",
+    "cpo:Moderator":         "http://example.com/cpo#cpo_0000005",
+    "cpo:ProximalOutcome":   "http://example.com/cpo#cpo_0000006",
+    "cpo:DistalOutcome":     "http://example.com/cpo#cpo_0000007",
+    "slowmo": "http://example.com/slowmo#",
+    "slowmo:PerformanceGapPositive":   "http://example.com/slowmo#PerformanceGapPositive",
+    "slowmo:PerformanceGapNegative":   "http://example.com/slowmo#PerformanceGapNegative",
+    "slowmo:PerformanceTrendPositive": "http://example.com/slowmo#PerformanceTrendPositive",
+    "slowmo:PerformanceTrendNegative": "http://example.com/slowmo#PerformanceTrendNegative",
+    "slowmo:NormativeComparator":      "http://example.com/slowmo#NormativeComparator",
+    "slowmo:PerformanceGapSize":       "http://example.com/slowmo#PerformanceGapSize",
+    "slowmo:HasPrecondition":   "http://example.com/slowmo#HasPrecondition",
+    "slowmo:HasModerator":      "http://example.com/slowmo#HasModerator",
+    "slowmo:ModeratorScore":    "http://example.com/slowmo#ModeratorScore",
+    "slowmo:Habituation":       "http://example.com/slowmo#Habituation",
+    "slowmo:RegulatoryFit":     "http://example.com/slowmo#RegulatoryFit",
+    "slowmo:SelfEfficacy":      "http://example.com/slowmo#SelfEfficacy",
+    "slowmo:Achievement":       "http://example.com/slowmo#Achievement",
+    "slowmo:Habituation":       "http://example.com/slowmo#Habituation"
+  },
+
+  "@graph": [
+    {
+      "@id": "",
+      "@type": "http://purl.obolibrary.org/obo/cpo_0000029",
+      "name": "",
+
+      "cpo:HasPrecondition":[ 
+        ""
+      ],
+
+      "slowmo:HasModerator":[
+        {"@type": "",
+          "slowmo:ModeratorScore": 100
+        },
+        {"@type": "",
+          "slowmo:ModeratorScore": 100
+        }
+      ],
+
+      "slowmo:ImplementationStrategy": "",
+      "cpo:Mechanism": "",
+      "cpo:ProximalOutcome": ["engagement", "acceptibility", "appropriateness"],
+      "cpo:DistalOutcome": [ 
+        "", 
+        "clinical practice is maintained"],
+      "slomo:KeyMessage": ""
+    }
+  ]
+}


### PR DESCRIPTION
Addresses #2 

- Provides example filled in causal pathway, benchmark achievement.
- Provides stubs for other casual pathways leaving empty strings `""` where information needs to be filled in.