### PR TITLE
Remove unusable precondition of social better pathway.

### DIFF
--- a/causal_pathways/social_better.json
+++ b/causal_pathways/social_better.json
@@ -18,7 +18,7 @@
     "psdo:SocialComparatorContent":                     "http://purl.obolibrary.org/obo/psdo_0000095",
     "psdo:SocialComparatorElement":                     "http://purl.obolibrary.org/obo/psdo_0000045",
     "psdo:PositivePerformanceGapContent":               "http://purl.obolibrary.org/obo/psdo_0000104",
-    "psdo:PositivePerformanceGapSet":	                "http://purl.obolibrary.org/obo/psdo_0000117",
+    "psdo:PositivePerformanceGapSet":                   "http://purl.obolibrary.org/obo/psdo_0000117",
     "psdo:NegativePerformanceGapContent":               "http://purl.obolibrary.org/obo/psdo_0000105",
     "slowmo":                                           "http://example.com/slowmo#",
     "slowmo:PerformanceGapSize":                        "http://example.com/slowmo#PerformanceGapSize",
@@ -48,9 +48,8 @@
       "cpo:Mechanism": ["knowledge", "subjective norms"],
 
       "slowmo:HasPrecondition":[
-        {"@type": "http://purl.obolibrary.org/obo/psdo_0000097"},
         {"@type": "http://purl.obolibrary.org/obo/psdo_0000041"},
-      	{"@type": "http://purl.obolibrary.org/obo/psdo_0000095"},
+        {"@type": "http://purl.obolibrary.org/obo/psdo_0000095"},
         {"@type": "http://purl.obolibrary.org/obo/psdo_0000045"},
         {"@type": "http://purl.obolibrary.org/obo/psdo_0000117"},
         {"@type": "http://purl.obolibrary.org/obo/psdo_0000104"}


### PR DESCRIPTION
  `recipient content` isn't an annotation being added to any performer.
  Corresponding element already present.
Avoid mixing tabs and spaces.
  Replace tabs with two spaces.