### PR TITLE
Message template JSON files created from Cedar

### DIFF
--- a/message_templates/achieve_peer_average.json
+++ b/message_templates/achieve_peer_average.json
@@ -1,0 +1,89 @@
+{
+  "@context": {
+    "schema:isBasedOn": {
+      "@type": "@id"
+    },
+    "schema:name": {
+      "@type": "xsd:string"
+    },
+    "schema": "http://schema.org/",
+    "pav": "http://purl.org/pav/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "oslc:modifiedBy": {
+      "@type": "@id"
+    },
+    "rdfs:label": {
+      "@type": "xsd:string"
+    },
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "pav:derivedFrom": {
+      "@type": "@id"
+    },
+    "pav:lastUpdatedOn": {
+      "@type": "xsd:dateTime"
+    },
+    "oslc": "http://open-services.net/ns/core#",
+    "pav:createdOn": {
+      "@type": "xsd:dateTime"
+    },
+    "skos:notation": {
+      "@type": "xsd:string"
+    },
+    "schema:description": {
+      "@type": "xsd:string"
+    },
+    "pav:createdBy": {
+      "@type": "@id"
+    },
+    "is_about": "http://purl.obolibrary.org/obo/IAO_0000136",
+    "Name": "https://schema.metadatacenter.org/properties/26450fa6-bb2c-4126-8229-79efda7f863a",
+    "Message text": "https://schema.metadatacenter.org/properties/6b9dfdf9-9c8a-4d85-8684-a24bee4b85a8"
+  },
+  "@type": "http://data.bioontology.org/ontologies/PSDO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FPSDO_0000002",
+  "is_about": [
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000117",
+      "rdfs:label": "positive performance gap set"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000045",
+      "rdfs:label": "social comparator element"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000120",
+      "rdfs:label": "positive performance trend set"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000121",
+      "rdfs:label": "achievement set"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000126",
+      "rdfs:label": "peer average comparator"
+    }
+  ],
+  "Name": {
+    "@value": "Achieve Peer Average"
+  },
+  "Message text": [
+    {
+      "@value": "Your performance is above the peer average this month for the measure [Measure name]."
+    }
+  ],
+  "schema:isBasedOn": "https://repo.metadatacenter.org/templates/707d3573-8ac9-4e2c-b53b-2026a795308c",
+  "schema:name": "Achieved Peer Average",
+  "schema:description": "specification for a possible precision feedback message",
+  "pav:createdOn": "2023-04-26T14:40:04-07:00",
+  "pav:createdBy": "https://metadatacenter.org/users/da882240-ad9e-42ea-a48b-215e54161ad3",
+  "pav:lastUpdatedOn": "2023-05-24T12:29:53-07:00",
+  "oslc:modifiedBy": "https://metadatacenter.org/users/b62c6dfa-e33c-40fa-aa02-021e4b9bb00b",
+  "@id": "https://repo.metadatacenter.org/template-instances/8927dac9-5088-4236-b91d-ff92756f6ac5",
+  "Display compatibility": {
+    "@value": "Text-only, bar chart, line chart"
+  },
+  "Short message ID": {
+    "@value": "4",
+    "@type": "xsd:decimal"
+  }
+}

--- a/message_templates/achieved_top_10_peer_benchmark.json
+++ b/message_templates/achieved_top_10_peer_benchmark.json
@@ -1,0 +1,89 @@
+{
+  "@context": {
+    "schema:isBasedOn": {
+      "@type": "@id"
+    },
+    "schema:name": {
+      "@type": "xsd:string"
+    },
+    "schema": "http://schema.org/",
+    "pav": "http://purl.org/pav/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "oslc:modifiedBy": {
+      "@type": "@id"
+    },
+    "rdfs:label": {
+      "@type": "xsd:string"
+    },
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "pav:derivedFrom": {
+      "@type": "@id"
+    },
+    "pav:lastUpdatedOn": {
+      "@type": "xsd:dateTime"
+    },
+    "oslc": "http://open-services.net/ns/core#",
+    "pav:createdOn": {
+      "@type": "xsd:dateTime"
+    },
+    "skos:notation": {
+      "@type": "xsd:string"
+    },
+    "schema:description": {
+      "@type": "xsd:string"
+    },
+    "pav:createdBy": {
+      "@type": "@id"
+    },
+    "is_about": "http://purl.obolibrary.org/obo/IAO_0000136",
+    "Name": "https://schema.metadatacenter.org/properties/26450fa6-bb2c-4126-8229-79efda7f863a",
+    "Message text": "https://schema.metadatacenter.org/properties/6b9dfdf9-9c8a-4d85-8684-a24bee4b85a8"
+  },
+  "@type": "http://data.bioontology.org/ontologies/PSDO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FPSDO_0000002",
+  "is_about": [
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000117",
+      "rdfs:label": "positive performance gap set"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000045",
+      "rdfs:label": "social comparator element"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000120",
+      "rdfs:label": "positive performance trend set"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000121",
+      "rdfs:label": "achievement set"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000129",
+      "rdfs:label": "peer 90th percentile benchmark"
+    }
+  ],
+  "Name": {
+    "@value": "Achieved Top 10 Peer Benchmark"
+  },
+  "Message text": [
+    {
+      "@value": "You reached the top 10% peer benchmark this month for the measure [Measure name]."
+    }
+  ],
+  "schema:isBasedOn": "https://repo.metadatacenter.org/templates/707d3573-8ac9-4e2c-b53b-2026a795308c",
+  "schema:name": "Achieved Top 10 Peer Benchmark",
+  "schema:description": "specification for a possible precision feedback message",
+  "pav:createdOn": "2023-04-26T14:29:04-07:00",
+  "pav:createdBy": "https://metadatacenter.org/users/da882240-ad9e-42ea-a48b-215e54161ad3",
+  "pav:lastUpdatedOn": "2023-05-23T12:01:27-07:00",
+  "oslc:modifiedBy": "https://metadatacenter.org/users/626c7d49-cdfc-43d6-b254-36a7be904ea9",
+  "@id": "https://repo.metadatacenter.org/template-instances/5c49f6e6-b95f-4eb9-baa9-dac580e33e20",
+  "Display compatibility": {
+    "@value": "Text-only, bar chart, line chart"
+  },
+  "Short message ID": {
+    "@value": "2",
+    "@type": "xsd:decimal"
+  }
+}

--- a/message_templates/achieved_top_25_peer_benchmark.json
+++ b/message_templates/achieved_top_25_peer_benchmark.json
@@ -1,0 +1,90 @@
+{
+  "@context": {
+    "schema:isBasedOn": {
+      "@type": "@id"
+    },
+    "schema:name": {
+      "@type": "xsd:string"
+    },
+    "schema": "http://schema.org/",
+    "pav": "http://purl.org/pav/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "oslc:modifiedBy": {
+      "@type": "@id"
+    },
+    "rdfs:label": {
+      "@type": "xsd:string"
+    },
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "pav:derivedFrom": {
+      "@type": "@id"
+    },
+    "pav:lastUpdatedOn": {
+      "@type": "xsd:dateTime"
+    },
+    "oslc": "http://open-services.net/ns/core#",
+    "pav:createdOn": {
+      "@type": "xsd:dateTime"
+    },
+    "skos:notation": {
+      "@type": "xsd:string"
+    },
+    "schema:description": {
+      "@type": "xsd:string"
+    },
+    "pav:createdBy": {
+      "@type": "@id"
+    },
+    "is_about": "http://purl.obolibrary.org/obo/IAO_0000136",
+    "Name": "https://schema.metadatacenter.org/properties/26450fa6-bb2c-4126-8229-79efda7f863a",
+    "Message text": "https://schema.metadatacenter.org/properties/6b9dfdf9-9c8a-4d85-8684-a24bee4b85a8"
+  },
+  "@type": "http://data.bioontology.org/ontologies/PSDO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FPSDO_0000002",
+  "is_about": [
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000117",
+      "rdfs:label": "positive performance gap set"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000045",
+      "rdfs:label": "social comparator element"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000120",
+      "rdfs:label": "positive performance trend set"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000121",
+      "rdfs:label": "achievement set"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000128",
+      "rdfs:label": "peer 75th percentile benchmark"
+    }
+  ],
+  "Name": {
+    "@value": "Achieved Top 25 Peer Benchmark"
+  },
+  "Message text": [
+    {
+      "@value": "You reached the top 25% peer benchmark this month for the measure [Measure name]."
+    }
+  ],
+  "schema:isBasedOn": "https://repo.metadatacenter.org/templates/707d3573-8ac9-4e2c-b53b-2026a795308c",
+  "schema:name": "Achieved Top 25 Peer Benchmark",
+  "schema:description": "specification for a possible precision feedback message",
+  "pav:createdOn": "2023-04-26T14:32:04-07:00",
+  "pav:createdBy": "https://metadatacenter.org/users/da882240-ad9e-42ea-a48b-215e54161ad3",
+  "pav:lastUpdatedOn": "2023-05-24T12:30:29-07:00",
+  "oslc:modifiedBy": "https://metadatacenter.org/users/b62c6dfa-e33c-40fa-aa02-021e4b9bb00b",
+  "pav:derivedFrom": "https://repo.metadatacenter.org/template-instances/5c49f6e6-b95f-4eb9-baa9-dac580e33e20",
+  "@id": "https://repo.metadatacenter.org/template-instances/75bd50a3-c11b-4a61-96e6-eee1f34eff78",
+  "Display compatibility": {
+    "@value": "Text-only, bar chart, line chart"
+  },
+  "Short message ID": {
+    "@value": "3",
+    "@type": "xsd:decimal"
+  }
+}

--- a/message_templates/approach_goal.json
+++ b/message_templates/approach_goal.json
@@ -1,0 +1,81 @@
+{
+  "@context": {
+    "schema:isBasedOn": {
+      "@type": "@id"
+    },
+    "schema:name": {
+      "@type": "xsd:string"
+    },
+    "schema": "http://schema.org/",
+    "pav": "http://purl.org/pav/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "oslc:modifiedBy": {
+      "@type": "@id"
+    },
+    "rdfs:label": {
+      "@type": "xsd:string"
+    },
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "pav:derivedFrom": {
+      "@type": "@id"
+    },
+    "pav:lastUpdatedOn": {
+      "@type": "xsd:dateTime"
+    },
+    "oslc": "http://open-services.net/ns/core#",
+    "pav:createdOn": {
+      "@type": "xsd:dateTime"
+    },
+    "skos:notation": {
+      "@type": "xsd:string"
+    },
+    "schema:description": {
+      "@type": "xsd:string"
+    },
+    "pav:createdBy": {
+      "@type": "@id"
+    },
+    "is_about": "http://purl.obolibrary.org/obo/IAO_0000136",
+    "Name": "https://schema.metadatacenter.org/properties/26450fa6-bb2c-4126-8229-79efda7f863a",
+    "Message text": "https://schema.metadatacenter.org/properties/6b9dfdf9-9c8a-4d85-8684-a24bee4b85a8"
+  },
+  "@type": "http://data.bioontology.org/ontologies/PSDO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FPSDO_0000002",
+  "is_about": [
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000116",
+      "rdfs:label": "negative performance gap set"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000046",
+      "rdfs:label": "goal comparator element"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000120",
+      "rdfs:label": "positive performance trend set"
+    }
+  ],
+  "Name": {
+    "@value": "Approach Goal"
+  },
+  "Message text": [
+    {
+      "@value": "Your performance is approaching the goal this month for the measure [Measure name]."
+    }
+  ],
+  "schema:isBasedOn": "https://repo.metadatacenter.org/templates/707d3573-8ac9-4e2c-b53b-2026a795308c",
+  "schema:name": "Approach Goal",
+  "schema:description": "specification for a possible precision feedback message",
+  "pav:createdOn": "2023-04-26T15:32:17-07:00",
+  "pav:createdBy": "https://metadatacenter.org/users/da882240-ad9e-42ea-a48b-215e54161ad3",
+  "pav:lastUpdatedOn": "2023-05-24T12:31:22-07:00",
+  "oslc:modifiedBy": "https://metadatacenter.org/users/b62c6dfa-e33c-40fa-aa02-021e4b9bb00b",
+  "@id": "https://repo.metadatacenter.org/template-instances/70fbdb71-fd31-45b0-8432-2bfa1bff200d",
+  "Display compatibility": {
+    "@value": "Text-only, bar chart, line chart"
+  },
+  "Short message ID": {
+    "@value": "17",
+    "@type": "xsd:decimal"
+  }
+}

--- a/message_templates/approach_peer_average.json
+++ b/message_templates/approach_peer_average.json
@@ -1,0 +1,85 @@
+{
+  "@context": {
+    "schema:isBasedOn": {
+      "@type": "@id"
+    },
+    "schema:name": {
+      "@type": "xsd:string"
+    },
+    "schema": "http://schema.org/",
+    "pav": "http://purl.org/pav/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "oslc:modifiedBy": {
+      "@type": "@id"
+    },
+    "rdfs:label": {
+      "@type": "xsd:string"
+    },
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "pav:derivedFrom": {
+      "@type": "@id"
+    },
+    "pav:lastUpdatedOn": {
+      "@type": "xsd:dateTime"
+    },
+    "oslc": "http://open-services.net/ns/core#",
+    "pav:createdOn": {
+      "@type": "xsd:dateTime"
+    },
+    "skos:notation": {
+      "@type": "xsd:string"
+    },
+    "schema:description": {
+      "@type": "xsd:string"
+    },
+    "pav:createdBy": {
+      "@type": "@id"
+    },
+    "is_about": "http://purl.obolibrary.org/obo/IAO_0000136",
+    "Name": "https://schema.metadatacenter.org/properties/26450fa6-bb2c-4126-8229-79efda7f863a",
+    "Message text": "https://schema.metadatacenter.org/properties/6b9dfdf9-9c8a-4d85-8684-a24bee4b85a8"
+  },
+  "@type": "http://data.bioontology.org/ontologies/PSDO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FPSDO_0000002",
+  "is_about": [
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000116",
+      "rdfs:label": "negative performance gap set"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000045",
+      "rdfs:label": "social comparator element"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000126",
+      "rdfs:label": "peer average comparator"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000120",
+      "rdfs:label": "positive performance trend set"
+    }
+  ],
+  "Name": {
+    "@value": "Approach Peer Average"
+  },
+  "Message text": [
+    {
+      "@value": "Your performance is approaching the peer average this month for the measure [Measure name]."
+    }
+  ],
+  "schema:isBasedOn": "https://repo.metadatacenter.org/templates/707d3573-8ac9-4e2c-b53b-2026a795308c",
+  "schema:name": "Approach Peer Average",
+  "schema:description": "specification for a possible precision feedback message",
+  "pav:createdOn": "2023-04-26T15:20:17-07:00",
+  "pav:createdBy": "https://metadatacenter.org/users/da882240-ad9e-42ea-a48b-215e54161ad3",
+  "pav:lastUpdatedOn": "2023-05-24T12:31:54-07:00",
+  "oslc:modifiedBy": "https://metadatacenter.org/users/b62c6dfa-e33c-40fa-aa02-021e4b9bb00b",
+  "@id": "https://repo.metadatacenter.org/template-instances/004d3aeb-b90a-4e4d-8359-b190d1ab8532",
+  "Display compatibility": {
+    "@value": "Text-only, bar chart, line chart"
+  },
+  "Short message ID": {
+    "@value": "10",
+    "@type": "xsd:decimal"
+  }
+}

--- a/message_templates/approach_top_10_peer_benchmark.json
+++ b/message_templates/approach_top_10_peer_benchmark.json
@@ -1,0 +1,85 @@
+{
+  "@context": {
+    "schema:isBasedOn": {
+      "@type": "@id"
+    },
+    "schema:name": {
+      "@type": "xsd:string"
+    },
+    "schema": "http://schema.org/",
+    "pav": "http://purl.org/pav/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "oslc:modifiedBy": {
+      "@type": "@id"
+    },
+    "rdfs:label": {
+      "@type": "xsd:string"
+    },
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "pav:derivedFrom": {
+      "@type": "@id"
+    },
+    "pav:lastUpdatedOn": {
+      "@type": "xsd:dateTime"
+    },
+    "oslc": "http://open-services.net/ns/core#",
+    "pav:createdOn": {
+      "@type": "xsd:dateTime"
+    },
+    "skos:notation": {
+      "@type": "xsd:string"
+    },
+    "schema:description": {
+      "@type": "xsd:string"
+    },
+    "pav:createdBy": {
+      "@type": "@id"
+    },
+    "is_about": "http://purl.obolibrary.org/obo/IAO_0000136",
+    "Name": "https://schema.metadatacenter.org/properties/26450fa6-bb2c-4126-8229-79efda7f863a",
+    "Message text": "https://schema.metadatacenter.org/properties/6b9dfdf9-9c8a-4d85-8684-a24bee4b85a8"
+  },
+  "@type": "http://data.bioontology.org/ontologies/PSDO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FPSDO_0000002",
+  "is_about": [
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000116",
+      "rdfs:label": "negative performance gap set"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000129",
+      "rdfs:label": "peer 90th percentile benchmark"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000045",
+      "rdfs:label": "social comparator element"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000120",
+      "rdfs:label": "positive performance trend set"
+    }
+  ],
+  "Name": {
+    "@value": "Approach Top 10 Peer Benchmark"
+  },
+  "Message text": [
+    {
+      "@value": "Your performance is approaching the top 10% peer benchmark this month for the measure [Measure name]."
+    }
+  ],
+  "schema:isBasedOn": "https://repo.metadatacenter.org/templates/707d3573-8ac9-4e2c-b53b-2026a795308c",
+  "schema:name": "Approach Top 10 Peer Benchmark",
+  "schema:description": "specification for a possible precision feedback message",
+  "pav:createdOn": "2023-04-26T15:21:34-07:00",
+  "pav:createdBy": "https://metadatacenter.org/users/da882240-ad9e-42ea-a48b-215e54161ad3",
+  "pav:lastUpdatedOn": "2023-05-24T12:32:15-07:00",
+  "oslc:modifiedBy": "https://metadatacenter.org/users/b62c6dfa-e33c-40fa-aa02-021e4b9bb00b",
+  "@id": "https://repo.metadatacenter.org/template-instances/17a4e0f8-5fc1-44bb-b243-8b4a33be1238",
+  "Display compatibility": {
+    "@value": "Text-only, bar chart, line chart"
+  },
+  "Short message ID": {
+    "@value": "11",
+    "@type": "xsd:decimal"
+  }
+}

--- a/message_templates/bar_chart.json
+++ b/message_templates/bar_chart.json
@@ -1,0 +1,70 @@
+{
+  "@context": {
+    "schema:isBasedOn": {
+      "@type": "@id"
+    },
+    "schema:name": {
+      "@type": "xsd:string"
+    },
+    "schema": "http://schema.org/",
+    "pav": "http://purl.org/pav/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "oslc:modifiedBy": {
+      "@type": "@id"
+    },
+    "rdfs:label": {
+      "@type": "xsd:string"
+    },
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "pav:derivedFrom": {
+      "@type": "@id"
+    },
+    "pav:lastUpdatedOn": {
+      "@type": "xsd:dateTime"
+    },
+    "oslc": "http://open-services.net/ns/core#",
+    "pav:createdOn": {
+      "@type": "xsd:dateTime"
+    },
+    "skos:notation": {
+      "@type": "xsd:string"
+    },
+    "schema:description": {
+      "@type": "xsd:string"
+    },
+    "pav:createdBy": {
+      "@type": "@id"
+    },
+    "is_about": "http://purl.obolibrary.org/obo/IAO_0000136",
+    "Name": "https://schema.metadatacenter.org/properties/26450fa6-bb2c-4126-8229-79efda7f863a",
+    "Message text": "https://schema.metadatacenter.org/properties/6b9dfdf9-9c8a-4d85-8684-a24bee4b85a8"
+  },
+  "@type": "http://data.bioontology.org/ontologies/PSDO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FPSDO_0000002",
+  "is_about": [
+    {}
+  ],
+  "Name": {
+    "@value": "Bar Chart"
+  },
+  "Message text": [
+    {
+      "@value": "The bar chart on the right shows your monthly performance for the measure [Measure name]."
+    }
+  ],
+  "schema:isBasedOn": "https://repo.metadatacenter.org/templates/707d3573-8ac9-4e2c-b53b-2026a795308c",
+  "schema:name": "Bar Chart_missing preconditions",
+  "schema:description": "specification for a possible precision feedback message",
+  "pav:createdOn": "2023-04-26T15:36:53-07:00",
+  "pav:createdBy": "https://metadatacenter.org/users/da882240-ad9e-42ea-a48b-215e54161ad3",
+  "pav:lastUpdatedOn": "2023-05-24T12:53:41-07:00",
+  "oslc:modifiedBy": "https://metadatacenter.org/users/b62c6dfa-e33c-40fa-aa02-021e4b9bb00b",
+  "@id": "https://repo.metadatacenter.org/template-instances/b7623442-b2f8-4505-a746-8ac6931c487d",
+  "Display compatibility": {
+    "@value": "Text-only, bar chart, line chart"
+  },
+  "Short message ID": {
+    "@value": "22",
+    "@type": "xsd:decimal"
+  }
+}

--- a/message_templates/congrats_improved_performance.json
+++ b/message_templates/congrats_improved_performance.json
@@ -1,0 +1,73 @@
+{
+  "@context": {
+    "schema:isBasedOn": {
+      "@type": "@id"
+    },
+    "schema:name": {
+      "@type": "xsd:string"
+    },
+    "schema": "http://schema.org/",
+    "pav": "http://purl.org/pav/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "oslc:modifiedBy": {
+      "@type": "@id"
+    },
+    "rdfs:label": {
+      "@type": "xsd:string"
+    },
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "pav:derivedFrom": {
+      "@type": "@id"
+    },
+    "pav:lastUpdatedOn": {
+      "@type": "xsd:dateTime"
+    },
+    "oslc": "http://open-services.net/ns/core#",
+    "pav:createdOn": {
+      "@type": "xsd:dateTime"
+    },
+    "skos:notation": {
+      "@type": "xsd:string"
+    },
+    "schema:description": {
+      "@type": "xsd:string"
+    },
+    "pav:createdBy": {
+      "@type": "@id"
+    },
+    "is_about": "http://purl.obolibrary.org/obo/IAO_0000136",
+    "Name": "https://schema.metadatacenter.org/properties/26450fa6-bb2c-4126-8229-79efda7f863a",
+    "Message text": "https://schema.metadatacenter.org/properties/6b9dfdf9-9c8a-4d85-8684-a24bee4b85a8"
+  },
+  "@type": "http://data.bioontology.org/ontologies/PSDO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FPSDO_0000002",
+  "is_about": [
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000120",
+      "rdfs:label": "positive performance trend set"
+    }
+  ],
+  "Name": {
+    "@value": "Congrats Improved Performance"
+  },
+  "Message text": [
+    {
+      "@value": "Congratulations on your improved performance this month for the measure [Measure name]."
+    }
+  ],
+  "schema:isBasedOn": "https://repo.metadatacenter.org/templates/707d3573-8ac9-4e2c-b53b-2026a795308c",
+  "schema:name": "Congrats Improved Performance",
+  "schema:description": "specification for a possible precision feedback message",
+  "pav:createdOn": "2023-04-26T15:34:17-07:00",
+  "pav:createdBy": "https://metadatacenter.org/users/da882240-ad9e-42ea-a48b-215e54161ad3",
+  "pav:lastUpdatedOn": "2023-05-24T12:33:27-07:00",
+  "oslc:modifiedBy": "https://metadatacenter.org/users/b62c6dfa-e33c-40fa-aa02-021e4b9bb00b",
+  "@id": "https://repo.metadatacenter.org/template-instances/e2ccba14-087a-4e6e-9ab7-1a69c88cbca2",
+  "Display compatibility": {
+    "@value": "Text-only, bar chart, line chart"
+  },
+  "Short message ID": {
+    "@value": "19",
+    "@type": "xsd:decimal"
+  }
+}

--- a/message_templates/consistently_high_performance.json
+++ b/message_templates/consistently_high_performance.json
@@ -1,0 +1,77 @@
+{
+  "@context": {
+    "schema:isBasedOn": {
+      "@type": "@id"
+    },
+    "schema:name": {
+      "@type": "xsd:string"
+    },
+    "schema": "http://schema.org/",
+    "pav": "http://purl.org/pav/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "oslc:modifiedBy": {
+      "@type": "@id"
+    },
+    "rdfs:label": {
+      "@type": "xsd:string"
+    },
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "pav:derivedFrom": {
+      "@type": "@id"
+    },
+    "pav:lastUpdatedOn": {
+      "@type": "xsd:dateTime"
+    },
+    "oslc": "http://open-services.net/ns/core#",
+    "pav:createdOn": {
+      "@type": "xsd:dateTime"
+    },
+    "skos:notation": {
+      "@type": "xsd:string"
+    },
+    "schema:description": {
+      "@type": "xsd:string"
+    },
+    "pav:createdBy": {
+      "@type": "@id"
+    },
+    "is_about": "http://purl.obolibrary.org/obo/IAO_0000136",
+    "Name": "https://schema.metadatacenter.org/properties/26450fa6-bb2c-4126-8229-79efda7f863a",
+    "Message text": "https://schema.metadatacenter.org/properties/6b9dfdf9-9c8a-4d85-8684-a24bee4b85a8"
+  },
+  "@type": "http://data.bioontology.org/ontologies/PSDO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FPSDO_0000002",
+  "is_about": [
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000117",
+      "rdfs:label": "positive performance gap set"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000045",
+      "rdfs:label": "social comparator element"
+    }
+  ],
+  "Name": {
+    "@value": "Consistently High Performance"
+  },
+  "Message text": [
+    {
+      "@value": "Congratulations on your consistently high performance for the measure [Measure name]."
+    }
+  ],
+  "schema:isBasedOn": "https://repo.metadatacenter.org/templates/707d3573-8ac9-4e2c-b53b-2026a795308c",
+  "schema:name": "Consistently High Performance_missing precondition",
+  "schema:description": "specification for a possible precision feedback message",
+  "pav:createdOn": "2023-04-26T14:43:13-07:00",
+  "pav:createdBy": "https://metadatacenter.org/users/da882240-ad9e-42ea-a48b-215e54161ad3",
+  "pav:lastUpdatedOn": "2023-05-24T12:34:00-07:00",
+  "oslc:modifiedBy": "https://metadatacenter.org/users/b62c6dfa-e33c-40fa-aa02-021e4b9bb00b",
+  "@id": "https://repo.metadatacenter.org/template-instances/c5694e6f-bb6c-4dbb-bbad-462c4be69447",
+  "Display compatibility": {
+    "@value": "Text-only, bar chart, line chart"
+  },
+  "Short message ID": {
+    "@value": "5",
+    "@type": "xsd:decimal"
+  }
+}

--- a/message_templates/drop_below_goal.json
+++ b/message_templates/drop_below_goal.json
@@ -1,0 +1,85 @@
+{
+  "@context": {
+    "schema:isBasedOn": {
+      "@type": "@id"
+    },
+    "schema:name": {
+      "@type": "xsd:string"
+    },
+    "schema": "http://schema.org/",
+    "pav": "http://purl.org/pav/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "oslc:modifiedBy": {
+      "@type": "@id"
+    },
+    "rdfs:label": {
+      "@type": "xsd:string"
+    },
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "pav:derivedFrom": {
+      "@type": "@id"
+    },
+    "pav:lastUpdatedOn": {
+      "@type": "xsd:dateTime"
+    },
+    "oslc": "http://open-services.net/ns/core#",
+    "pav:createdOn": {
+      "@type": "xsd:dateTime"
+    },
+    "skos:notation": {
+      "@type": "xsd:string"
+    },
+    "schema:description": {
+      "@type": "xsd:string"
+    },
+    "pav:createdBy": {
+      "@type": "@id"
+    },
+    "is_about": "http://purl.obolibrary.org/obo/IAO_0000136",
+    "Name": "https://schema.metadatacenter.org/properties/26450fa6-bb2c-4126-8229-79efda7f863a",
+    "Message text": "https://schema.metadatacenter.org/properties/6b9dfdf9-9c8a-4d85-8684-a24bee4b85a8"
+  },
+  "@type": "http://data.bioontology.org/ontologies/PSDO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FPSDO_0000002",
+  "is_about": [
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000116",
+      "rdfs:label": "negative performance gap set"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000046",
+      "rdfs:label": "goal comparator element"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000119",
+      "rdfs:label": "negative performance trend set"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000122",
+      "rdfs:label": "loss set"
+    }
+  ],
+  "Name": {
+    "@value": "Drop Below Goal"
+  },
+  "Message text": [
+    {
+      "@value": "Your performance dropped below the goal this month for the measure [Measure name]."
+    }
+  ],
+  "schema:isBasedOn": "https://repo.metadatacenter.org/templates/707d3573-8ac9-4e2c-b53b-2026a795308c",
+  "schema:name": "Drop Below Goal",
+  "schema:description": "specification for a possible precision feedback message",
+  "pav:createdOn": "2023-04-26T15:26:28-07:00",
+  "pav:createdBy": "https://metadatacenter.org/users/da882240-ad9e-42ea-a48b-215e54161ad3",
+  "pav:lastUpdatedOn": "2023-05-24T12:34:30-07:00",
+  "oslc:modifiedBy": "https://metadatacenter.org/users/b62c6dfa-e33c-40fa-aa02-021e4b9bb00b",
+  "@id": "https://repo.metadatacenter.org/template-instances/bbac24d6-c9e0-41f8-a5fd-3ea677402c06",
+  "Display compatibility": {
+    "@value": "Text-only, bar chart, line chart"
+  },
+  "Short message ID": {
+    "@value": "15",
+    "@type": "xsd:decimal"
+  }
+}

--- a/message_templates/getting_worse.json
+++ b/message_templates/getting_worse.json
@@ -1,0 +1,73 @@
+{
+  "@context": {
+    "schema:isBasedOn": {
+      "@type": "@id"
+    },
+    "schema:name": {
+      "@type": "xsd:string"
+    },
+    "schema": "http://schema.org/",
+    "pav": "http://purl.org/pav/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "oslc:modifiedBy": {
+      "@type": "@id"
+    },
+    "rdfs:label": {
+      "@type": "xsd:string"
+    },
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "pav:derivedFrom": {
+      "@type": "@id"
+    },
+    "pav:lastUpdatedOn": {
+      "@type": "xsd:dateTime"
+    },
+    "oslc": "http://open-services.net/ns/core#",
+    "pav:createdOn": {
+      "@type": "xsd:dateTime"
+    },
+    "skos:notation": {
+      "@type": "xsd:string"
+    },
+    "schema:description": {
+      "@type": "xsd:string"
+    },
+    "pav:createdBy": {
+      "@type": "@id"
+    },
+    "is_about": "http://purl.obolibrary.org/obo/IAO_0000136",
+    "Name": "https://schema.metadatacenter.org/properties/26450fa6-bb2c-4126-8229-79efda7f863a",
+    "Message text": "https://schema.metadatacenter.org/properties/6b9dfdf9-9c8a-4d85-8684-a24bee4b85a8"
+  },
+  "@type": "http://data.bioontology.org/ontologies/PSDO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FPSDO_0000002",
+  "is_about": [
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000119",
+      "rdfs:label": "negative performance trend set"
+    }
+  ],
+  "Name": {
+    "@value": "Getting Worse"
+  },
+  "Message text": [
+    {
+      "@value": "Your performance is getting worse this month for the measure [Measure name]."
+    }
+  ],
+  "schema:isBasedOn": "https://repo.metadatacenter.org/templates/707d3573-8ac9-4e2c-b53b-2026a795308c",
+  "schema:name": "Getting Worse",
+  "schema:description": "specification for a possible precision feedback message",
+  "pav:createdOn": "2023-04-26T15:35:30-07:00",
+  "pav:createdBy": "https://metadatacenter.org/users/da882240-ad9e-42ea-a48b-215e54161ad3",
+  "pav:lastUpdatedOn": "2023-05-24T12:35:55-07:00",
+  "oslc:modifiedBy": "https://metadatacenter.org/users/b62c6dfa-e33c-40fa-aa02-021e4b9bb00b",
+  "@id": "https://repo.metadatacenter.org/template-instances/1f257d98-f6b0-44f6-92c8-1a194954f33f",
+  "Display compatibility": {
+    "@value": "Text-only, bar chart, line chart"
+  },
+  "Short message ID": {
+    "@value": "20",
+    "@type": "xsd:decimal"
+  }
+}

--- a/message_templates/line_chart.json
+++ b/message_templates/line_chart.json
@@ -1,0 +1,70 @@
+{
+  "@context": {
+    "schema:isBasedOn": {
+      "@type": "@id"
+    },
+    "schema:name": {
+      "@type": "xsd:string"
+    },
+    "schema": "http://schema.org/",
+    "pav": "http://purl.org/pav/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "oslc:modifiedBy": {
+      "@type": "@id"
+    },
+    "rdfs:label": {
+      "@type": "xsd:string"
+    },
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "pav:derivedFrom": {
+      "@type": "@id"
+    },
+    "pav:lastUpdatedOn": {
+      "@type": "xsd:dateTime"
+    },
+    "oslc": "http://open-services.net/ns/core#",
+    "pav:createdOn": {
+      "@type": "xsd:dateTime"
+    },
+    "skos:notation": {
+      "@type": "xsd:string"
+    },
+    "schema:description": {
+      "@type": "xsd:string"
+    },
+    "pav:createdBy": {
+      "@type": "@id"
+    },
+    "is_about": "http://purl.obolibrary.org/obo/IAO_0000136",
+    "Name": "https://schema.metadatacenter.org/properties/26450fa6-bb2c-4126-8229-79efda7f863a",
+    "Message text": "https://schema.metadatacenter.org/properties/6b9dfdf9-9c8a-4d85-8684-a24bee4b85a8"
+  },
+  "@type": "http://data.bioontology.org/ontologies/PSDO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FPSDO_0000002",
+  "is_about": [
+    {}
+  ],
+  "Name": {
+    "@value": "Line Chart"
+  },
+  "Message text": [
+    {
+      "@value": "The line chart on the right shows your monthly performance for the measure [Measure name]."
+    }
+  ],
+  "schema:isBasedOn": "https://repo.metadatacenter.org/templates/707d3573-8ac9-4e2c-b53b-2026a795308c",
+  "schema:name": "Line Chart_missing preconditions",
+  "schema:description": "specification for a possible precision feedback message",
+  "pav:createdOn": "2023-04-26T15:38:01-07:00",
+  "pav:createdBy": "https://metadatacenter.org/users/da882240-ad9e-42ea-a48b-215e54161ad3",
+  "pav:lastUpdatedOn": "2023-05-24T12:53:21-07:00",
+  "oslc:modifiedBy": "https://metadatacenter.org/users/b62c6dfa-e33c-40fa-aa02-021e4b9bb00b",
+  "@id": "https://repo.metadatacenter.org/template-instances/1c24bd7f-5895-49bc-a439-1820c7cfb573",
+  "Display compatibility": {
+    "@value": "Text-only, bar chart, line chart"
+  },
+  "Short message ID": {
+    "@value": "23",
+    "@type": "xsd:decimal"
+  }
+}

--- a/message_templates/not_top_performer.json
+++ b/message_templates/not_top_performer.json
@@ -1,0 +1,81 @@
+{
+  "@context": {
+    "schema:isBasedOn": {
+      "@type": "@id"
+    },
+    "schema:name": {
+      "@type": "xsd:string"
+    },
+    "schema": "http://schema.org/",
+    "pav": "http://purl.org/pav/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "oslc:modifiedBy": {
+      "@type": "@id"
+    },
+    "rdfs:label": {
+      "@type": "xsd:string"
+    },
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "pav:derivedFrom": {
+      "@type": "@id"
+    },
+    "pav:lastUpdatedOn": {
+      "@type": "xsd:dateTime"
+    },
+    "oslc": "http://open-services.net/ns/core#",
+    "pav:createdOn": {
+      "@type": "xsd:dateTime"
+    },
+    "skos:notation": {
+      "@type": "xsd:string"
+    },
+    "schema:description": {
+      "@type": "xsd:string"
+    },
+    "pav:createdBy": {
+      "@type": "@id"
+    },
+    "is_about": "http://purl.obolibrary.org/obo/IAO_0000136",
+    "Name": "https://schema.metadatacenter.org/properties/26450fa6-bb2c-4126-8229-79efda7f863a",
+    "Message text": "https://schema.metadatacenter.org/properties/6b9dfdf9-9c8a-4d85-8684-a24bee4b85a8"
+  },
+  "@type": "http://data.bioontology.org/ontologies/PSDO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FPSDO_0000002",
+  "is_about": [
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000116",
+      "rdfs:label": "negative performance gap set"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000129",
+      "rdfs:label": "peer 90th percentile benchmark"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000045",
+      "rdfs:label": "social comparator element"
+    }
+  ],
+  "Name": {
+    "@value": "Not Top Performer"
+  },
+  "Message text": [
+    {
+      "@value": "You are not a top performer this month for the measure [Measure name]. Your performance was [recipient performance level - percentage], below the [comparator name]."
+    }
+  ],
+  "schema:isBasedOn": "https://repo.metadatacenter.org/templates/707d3573-8ac9-4e2c-b53b-2026a795308c",
+  "schema:name": "Not Top Performer",
+  "schema:description": "specification for a possible precision feedback message",
+  "pav:createdOn": "2023-04-26T14:54:16-07:00",
+  "pav:createdBy": "https://metadatacenter.org/users/da882240-ad9e-42ea-a48b-215e54161ad3",
+  "pav:lastUpdatedOn": "2023-05-24T12:37:53-07:00",
+  "oslc:modifiedBy": "https://metadatacenter.org/users/b62c6dfa-e33c-40fa-aa02-021e4b9bb00b",
+  "@id": "https://repo.metadatacenter.org/template-instances/7a786bd2-e0e4-4c13-b3c6-a7228223dd4e",
+  "Display compatibility": {
+    "@value": "Text-only, bar chart, line chart"
+  },
+  "Short message ID": {
+    "@value": "6",
+    "@type": "xsd:decimal"
+  }
+}

--- a/message_templates/opportunity_to_improve.json
+++ b/message_templates/opportunity_to_improve.json
@@ -1,0 +1,77 @@
+{
+  "@context": {
+    "schema:isBasedOn": {
+      "@type": "@id"
+    },
+    "schema:name": {
+      "@type": "xsd:string"
+    },
+    "schema": "http://schema.org/",
+    "pav": "http://purl.org/pav/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "oslc:modifiedBy": {
+      "@type": "@id"
+    },
+    "rdfs:label": {
+      "@type": "xsd:string"
+    },
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "pav:derivedFrom": {
+      "@type": "@id"
+    },
+    "pav:lastUpdatedOn": {
+      "@type": "xsd:dateTime"
+    },
+    "oslc": "http://open-services.net/ns/core#",
+    "pav:createdOn": {
+      "@type": "xsd:dateTime"
+    },
+    "skos:notation": {
+      "@type": "xsd:string"
+    },
+    "schema:description": {
+      "@type": "xsd:string"
+    },
+    "pav:createdBy": {
+      "@type": "@id"
+    },
+    "is_about": "http://purl.obolibrary.org/obo/IAO_0000136",
+    "Name": "https://schema.metadatacenter.org/properties/26450fa6-bb2c-4126-8229-79efda7f863a",
+    "Message text": "https://schema.metadatacenter.org/properties/6b9dfdf9-9c8a-4d85-8684-a24bee4b85a8"
+  },
+  "@type": "http://data.bioontology.org/ontologies/PSDO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FPSDO_0000002",
+  "is_about": [
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000116",
+      "rdfs:label": "negative performance gap set"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000046",
+      "rdfs:label": "goal comparator element"
+    }
+  ],
+  "Name": {
+    "@value": "Opportunity to Improve"
+  },
+  "Message text": [
+    {
+      "@value": "You may have an opportunity to improve for the measure [Measure name]."
+    }
+  ],
+  "schema:isBasedOn": "https://repo.metadatacenter.org/templates/707d3573-8ac9-4e2c-b53b-2026a795308c",
+  "schema:name": "Opportunity to Improve_missing preconditions",
+  "schema:description": "specification for a possible precision feedback message",
+  "pav:createdOn": "2023-04-26T15:25:25-07:00",
+  "pav:createdBy": "https://metadatacenter.org/users/da882240-ad9e-42ea-a48b-215e54161ad3",
+  "pav:lastUpdatedOn": "2023-05-24T12:38:41-07:00",
+  "oslc:modifiedBy": "https://metadatacenter.org/users/b62c6dfa-e33c-40fa-aa02-021e4b9bb00b",
+  "@id": "https://repo.metadatacenter.org/template-instances/ffb029f4-104f-437d-9ea3-d85a46b4b87b",
+  "Display compatibility": {
+    "@value": "Text-only, bar chart, line chart"
+  },
+  "Short message ID": {
+    "@value": "14",
+    "@type": "xsd:decimal"
+  }
+}

--- a/message_templates/performance_dropped.json
+++ b/message_templates/performance_dropped.json
@@ -1,0 +1,73 @@
+{
+  "@context": {
+    "schema:isBasedOn": {
+      "@type": "@id"
+    },
+    "schema:name": {
+      "@type": "xsd:string"
+    },
+    "schema": "http://schema.org/",
+    "pav": "http://purl.org/pav/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "oslc:modifiedBy": {
+      "@type": "@id"
+    },
+    "rdfs:label": {
+      "@type": "xsd:string"
+    },
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "pav:derivedFrom": {
+      "@type": "@id"
+    },
+    "pav:lastUpdatedOn": {
+      "@type": "xsd:dateTime"
+    },
+    "oslc": "http://open-services.net/ns/core#",
+    "pav:createdOn": {
+      "@type": "xsd:dateTime"
+    },
+    "skos:notation": {
+      "@type": "xsd:string"
+    },
+    "schema:description": {
+      "@type": "xsd:string"
+    },
+    "pav:createdBy": {
+      "@type": "@id"
+    },
+    "is_about": "http://purl.obolibrary.org/obo/IAO_0000136",
+    "Name": "https://schema.metadatacenter.org/properties/26450fa6-bb2c-4126-8229-79efda7f863a",
+    "Message text": "https://schema.metadatacenter.org/properties/6b9dfdf9-9c8a-4d85-8684-a24bee4b85a8"
+  },
+  "@type": "http://data.bioontology.org/ontologies/PSDO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FPSDO_0000002",
+  "is_about": [
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000119",
+      "rdfs:label": "negative performance trend set"
+    }
+  ],
+  "Name": {
+    "@value": "Performance Dropped"
+  },
+  "Message text": [
+    {
+      "@value": "Your performance dropped this month for the measure [Measure name]."
+    }
+  ],
+  "schema:isBasedOn": "https://repo.metadatacenter.org/templates/707d3573-8ac9-4e2c-b53b-2026a795308c",
+  "schema:name": "Performance Dropped",
+  "schema:description": "specification for a possible precision feedback message",
+  "pav:createdOn": "2023-04-26T15:36:11-07:00",
+  "pav:createdBy": "https://metadatacenter.org/users/da882240-ad9e-42ea-a48b-215e54161ad3",
+  "pav:lastUpdatedOn": "2023-05-24T12:39:19-07:00",
+  "oslc:modifiedBy": "https://metadatacenter.org/users/b62c6dfa-e33c-40fa-aa02-021e4b9bb00b",
+  "@id": "https://repo.metadatacenter.org/template-instances/1effb7ae-2ec9-4832-867e-360d1f035837",
+  "Display compatibility": {
+    "@value": "Text-only, bar chart, line chart"
+  },
+  "Short message ID": {
+    "@value": "21",
+    "@type": "xsd:decimal"
+  }
+}

--- a/message_templates/performance_improving.json
+++ b/message_templates/performance_improving.json
@@ -1,0 +1,73 @@
+{
+  "@context": {
+    "schema:isBasedOn": {
+      "@type": "@id"
+    },
+    "schema:name": {
+      "@type": "xsd:string"
+    },
+    "schema": "http://schema.org/",
+    "pav": "http://purl.org/pav/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "oslc:modifiedBy": {
+      "@type": "@id"
+    },
+    "rdfs:label": {
+      "@type": "xsd:string"
+    },
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "pav:derivedFrom": {
+      "@type": "@id"
+    },
+    "pav:lastUpdatedOn": {
+      "@type": "xsd:dateTime"
+    },
+    "oslc": "http://open-services.net/ns/core#",
+    "pav:createdOn": {
+      "@type": "xsd:dateTime"
+    },
+    "skos:notation": {
+      "@type": "xsd:string"
+    },
+    "schema:description": {
+      "@type": "xsd:string"
+    },
+    "pav:createdBy": {
+      "@type": "@id"
+    },
+    "is_about": "http://purl.obolibrary.org/obo/IAO_0000136",
+    "Name": "https://schema.metadatacenter.org/properties/26450fa6-bb2c-4126-8229-79efda7f863a",
+    "Message text": "https://schema.metadatacenter.org/properties/6b9dfdf9-9c8a-4d85-8684-a24bee4b85a8"
+  },
+  "@type": "http://data.bioontology.org/ontologies/PSDO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FPSDO_0000002",
+  "is_about": [
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000120",
+      "rdfs:label": "positive performance trend set"
+    }
+  ],
+  "Name": {
+    "@value": "Performance Improving"
+  },
+  "Message text": [
+    {
+      "@value": "Your performance is improving this month for the measure [Measure name]."
+    }
+  ],
+  "schema:isBasedOn": "https://repo.metadatacenter.org/templates/707d3573-8ac9-4e2c-b53b-2026a795308c",
+  "schema:name": "Performance Improving",
+  "schema:description": "specification for a possible precision feedback message",
+  "pav:createdOn": "2023-04-26T15:33:33-07:00",
+  "pav:createdBy": "https://metadatacenter.org/users/da882240-ad9e-42ea-a48b-215e54161ad3",
+  "pav:lastUpdatedOn": "2023-05-24T12:39:44-07:00",
+  "oslc:modifiedBy": "https://metadatacenter.org/users/b62c6dfa-e33c-40fa-aa02-021e4b9bb00b",
+  "@id": "https://repo.metadatacenter.org/template-instances/0ae1872f-5593-4891-8713-7d5e815c0b00",
+  "Display compatibility": {
+    "@value": "Text-only, bar chart, line chart"
+  },
+  "Short message ID": {
+    "@value": "18",
+    "@type": "xsd:decimal"
+  }
+}

--- a/message_templates/reached_goal.json
+++ b/message_templates/reached_goal.json
@@ -1,0 +1,85 @@
+{
+  "@context": {
+    "schema:isBasedOn": {
+      "@type": "@id"
+    },
+    "schema:name": {
+      "@type": "xsd:string"
+    },
+    "schema": "http://schema.org/",
+    "pav": "http://purl.org/pav/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "oslc:modifiedBy": {
+      "@type": "@id"
+    },
+    "rdfs:label": {
+      "@type": "xsd:string"
+    },
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "pav:derivedFrom": {
+      "@type": "@id"
+    },
+    "pav:lastUpdatedOn": {
+      "@type": "xsd:dateTime"
+    },
+    "oslc": "http://open-services.net/ns/core#",
+    "pav:createdOn": {
+      "@type": "xsd:dateTime"
+    },
+    "skos:notation": {
+      "@type": "xsd:string"
+    },
+    "schema:description": {
+      "@type": "xsd:string"
+    },
+    "pav:createdBy": {
+      "@type": "@id"
+    },
+    "is_about": "http://purl.obolibrary.org/obo/IAO_0000136",
+    "Name": "https://schema.metadatacenter.org/properties/26450fa6-bb2c-4126-8229-79efda7f863a",
+    "Message text": "https://schema.metadatacenter.org/properties/6b9dfdf9-9c8a-4d85-8684-a24bee4b85a8"
+  },
+  "@type": "http://data.bioontology.org/ontologies/PSDO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FPSDO_0000002",
+  "is_about": [
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000117",
+      "rdfs:label": "positive performance gap set"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000120",
+      "rdfs:label": "positive performance trend set"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000046",
+      "rdfs:label": "goal comparator element"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000121",
+      "rdfs:label": "achievement set"
+    }
+  ],
+  "Name": {
+    "@value": "Reached Goal"
+  },
+  "Message text": [
+    {
+      "@value": "You reached the goal this month for the measure [Measure name]."
+    }
+  ],
+  "schema:isBasedOn": "https://repo.metadatacenter.org/templates/707d3573-8ac9-4e2c-b53b-2026a795308c",
+  "schema:name": "Reached Goal",
+  "schema:description": "specification for a possible precision feedback message",
+  "pav:createdOn": "2023-04-26T15:24:18-07:00",
+  "pav:createdBy": "https://metadatacenter.org/users/da882240-ad9e-42ea-a48b-215e54161ad3",
+  "pav:lastUpdatedOn": "2023-05-24T12:40:13-07:00",
+  "oslc:modifiedBy": "https://metadatacenter.org/users/b62c6dfa-e33c-40fa-aa02-021e4b9bb00b",
+  "@id": "https://repo.metadatacenter.org/template-instances/722d98b6-0dfd-40ff-8248-abeaaf4aad6d",
+  "Display compatibility": {
+    "@value": "Text-only, bar chart, line chart"
+  },
+  "Short message ID": {
+    "@value": "13",
+    "@type": "xsd:decimal"
+  }
+}

--- a/message_templates/remain_low_performance.json
+++ b/message_templates/remain_low_performance.json
@@ -1,0 +1,81 @@
+{
+  "@context": {
+    "schema:isBasedOn": {
+      "@type": "@id"
+    },
+    "schema:name": {
+      "@type": "xsd:string"
+    },
+    "schema": "http://schema.org/",
+    "pav": "http://purl.org/pav/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "oslc:modifiedBy": {
+      "@type": "@id"
+    },
+    "rdfs:label": {
+      "@type": "xsd:string"
+    },
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "pav:derivedFrom": {
+      "@type": "@id"
+    },
+    "pav:lastUpdatedOn": {
+      "@type": "xsd:dateTime"
+    },
+    "oslc": "http://open-services.net/ns/core#",
+    "pav:createdOn": {
+      "@type": "xsd:dateTime"
+    },
+    "skos:notation": {
+      "@type": "xsd:string"
+    },
+    "schema:description": {
+      "@type": "xsd:string"
+    },
+    "pav:createdBy": {
+      "@type": "@id"
+    },
+    "is_about": "http://purl.obolibrary.org/obo/IAO_0000136",
+    "Name": "https://schema.metadatacenter.org/properties/26450fa6-bb2c-4126-8229-79efda7f863a",
+    "Message text": "https://schema.metadatacenter.org/properties/6b9dfdf9-9c8a-4d85-8684-a24bee4b85a8"
+  },
+  "@type": "http://data.bioontology.org/ontologies/PSDO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FPSDO_0000002",
+  "is_about": [
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000116",
+      "rdfs:label": "negative performance gap set"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000045",
+      "rdfs:label": "social comparator element"
+    },
+    {
+      "@id": "http://purl.obolibrary.org/obo/PSDO_0000119",
+      "rdfs:label": "negative performance trend set"
+    }
+  ],
+  "Name": {
+    "@value": "Remain Low Performance"
+  },
+  "Message text": [
+    {
+      "@value": "Your performance has remained low for the measure [Measure name]."
+    }
+  ],
+  "schema:isBasedOn": "https://repo.metadatacenter.org/templates/707d3573-8ac9-4e2c-b53b-2026a795308c",
+  "schema:name": "Remain Low Performance_missing precondition",
+  "schema:description": "specification for a possible precision feedback message",
+  "pav:createdOn": "2023-04-26T15:01:34-07:00",
+  "pav:createdBy": "https://metadatacenter.org/users/da882240-ad9e-42ea-a48b-215e54161ad3",
+  "pav:lastUpdatedOn": "2023-05-24T12:41:33-07:00",
+  "oslc:modifiedBy": "https://metadatacenter.org/users/b62c6dfa-e33c-40fa-aa02-021e4b9bb00b",
+  "@id": "https://repo.metadatacenter.org/template-instances/d6308bc5-6509-4ba9-bb5a-1c54618c7058",
+  "Display compatibility": {
+    "@value": "Text-only, bar chart, line chart"
+  },
+  "Short message ID": {
+    "@value": "9",
+    "@type": "xsd:decimal"
+  }
+}


### PR DESCRIPTION
Created 18 new JSON files in patch-4, pulling directly from Cedar (after the short message ID update).

If we don't want all of these files added at once, I can leave this patch alone and pull them into main as we need. Your call!

Note: four templates are lacking preconditions (both here and in Cedar)
> Bar chart
> Line chart
> Opportunity to improve
> Remain low performance