### PR TITLE
Make Preferences Introductions Consistent

### DIFF
--- a/vignettes/goal_gain_vignette/readme.md
+++ b/vignettes/goal_gain_vignette/readme.md
@@ -13,8 +13,7 @@ Alice has a performance level of 97%.
 Alice's peer benchmarks for last month are 93% for the top 25% peer benchmark (75th percentile http://purl.obolibrary.org/obo/psdo_0000128), and 96% for the top 10% peer benchmark (90th percentile http://purl.obolibrary.org/obo/psdo_0000129).
 
 ## Preference data
-Preferences for precision feedback are elicited through a preference survey that providers can take. The preference survey produces a preference model for each provider that, with the provider's permission, is shared with MPOG to maintain. MPOG analyses preferences data that is shared to identify population-level preference segments. These are generates as preference profiles that can serve as a default preference model for an organization, or which can be selected by providers who do not take the preference survey, but who identify preferences that are close enough to their own in the settings menu for the precision feedback system.
-Alice's preference data: (TODO)
+Preferences for precision feedback are elicited through a preference survey that providers can take. The preference survey produces a preference model for each provider that, with the provider's permission, is shared with MPOG to maintain. MPOG analyses preference data that is shared to identify population-level preference segments. These segments are generated as preference profiles that can serve as a default preference model for an organization, or which can be selected by providers who do not take the preference survey, but who identify preferences that are close enough to their own in the settings menu for the precision feedback system.
 
 # Precision feedback system
 To generate precision feedback, MPOG sends de-identified performance and preference data to a precision feedback system that processes each provider's data with their peer comparator performance data, to select an optimal precision feedback message. 

--- a/vignettes/improving_vignette/readme.md
+++ b/vignettes/improving_vignette/readme.md
@@ -33,7 +33,7 @@ Gaile, a resident at Midwest Medicine, has the following performance data over t
 |Jan  |              95%|               97|          84|
 
 ## Preference data
-Preferences for precision feedback are elicited through a preference survey that providers can take. The preference survey produces a preference model for each provider that, with the provider's permission, is shared with MPOG to maintain. MPOG analyses preferences data that is shared to identify population-level preference segments. These are generates as preference profiles that can serve as a default preference model for an organization, or which can be selected by providers who do not take the preference survey, but who identify preferences that are close enough to their own in the settings menu for the precision feedback system.
+Preferences for precision feedback are elicited through a preference survey that providers can take. The preference survey produces a preference model for each provider that, with the provider's permission, is shared with MPOG to maintain. MPOG analyses preference data that is shared to identify population-level preference segments. These segments are generated as preference profiles that can serve as a default preference model for an organization, or which can be selected by providers who do not take the preference survey, but who identify preferences that are close enough to their own in the settings menu for the precision feedback system.
 
 Deepa's preference data:
 |Motivating information |Utility value|Description                                                                     |

--- a/vignettes/social_approach_vignette/readme.md
+++ b/vignettes/social_approach_vignette/readme.md
@@ -34,7 +34,7 @@ Deepa, another CRNA at Midwest Medicine, a medical-school affiliated hospital, h
 |Mar  |              85%|               91|          86|
 
 ## Preference data
-Preferences for precision feedback are elicited through a preference survey that providers can take. The preference survey produces a preference model for each provider that, with the provider's permission, is shared with MPOG to maintain. MPOG analyses preferences data that is shared to identify population-level preference segments. These are generates as preference profiles that can serve as a default preference model for an organization, or which can be selected by providers who do not take the preference survey, but who identify preferences that are close enough to their own in the settings menu for the precision feedback system.
+Preferences for precision feedback are elicited through a preference survey that providers can take. The preference survey produces a preference model for each provider that, with the provider's permission, is shared with MPOG to maintain. MPOG analyses preference data that is shared to identify population-level preference segments. These segments are generated as preference profiles that can serve as a default preference model for an organization, or which can be selected by providers who do not take the preference survey, but who identify preferences that are close enough to their own in the settings menu for the precision feedback system.
 
 Bob's preference data:
 

--- a/vignettes/social_better_vignette/readme.md
+++ b/vignettes/social_better_vignette/readme.md
@@ -35,7 +35,7 @@ Gaile, a resident anesthesiologist at Midwest Medicine, has the following perfor
 |Jan  |              93%|               96|          91|
 
 ## Preference data
-Preferences for precision feedback are elicited through a preference survey that providers can take. The preference survey produces a preference model for each provider that, with the provider's permission, is shared with MPOG to maintain. MPOG analyses preferences data that is shared to identify population-level preference segments. These are generates as preference profiles that can serve as a default preference model for an organization, or which can be selected by providers who do not take the preference survey, but who identify preferences that are close enough to their own in the settings menu for the precision feedback system.
+Preferences for precision feedback are elicited through a preference survey that providers can take. The preference survey produces a preference model for each provider that, with the provider's permission, is shared with MPOG to maintain. MPOG analyses preference data that is shared to identify population-level preference segments. These segments are generated as preference profiles that can serve as a default preference model for an organization, or which can be selected by providers who do not take the preference survey, but who identify preferences that are close enough to their own in the settings menu for the precision feedback system.
 
 Alice's preference data:
 |Motivating information |Utility value|Description                                                                     |

--- a/vignettes/social_gain_vignette/readme.md
+++ b/vignettes/social_gain_vignette/readme.md
@@ -35,6 +35,8 @@ Fahad, an attending pediatric anesthesiologist at Max Community Hospital, has th
 |Mar  |              97%|               95|          86|
 
 ## Preference data
+Preferences for precision feedback are elicited through a preference survey that providers can take. The preference survey produces a preference model for each provider that, with the provider's permission, is shared with MPOG to maintain. MPOG analyses preference data that is shared to identify population-level preference segments. These segments are generated as preference profiles that can serve as a default preference model for an organization, or which can be selected by providers who do not take the preference survey, but who identify preferences that are close enough to their own in the settings menu for the precision feedback system.
+
 Chikondi's preference data:
 
 |Motivating information |Utility value|Description                                                                     |

--- a/vignettes/social_worse_vignette/readme.md
+++ b/vignettes/social_worse_vignette/readme.md
@@ -35,7 +35,7 @@ Eugene, a resident anesthesiologist at Midwest Medicine, has the following perfo
 |Mar  |              93%|               95|          85|
 
 ## Preference data
-Preferences for precision feedback are elicited through a preference survey that providers can take. The preference survey produces a preference model for each provider that, with the provider's permission, is shared with MPOG to maintain. MPOG analyses preferences data that is shared to identify population-level preference segments. These are generates as preference profiles that can serve as a default preference model for an organization, or which can be selected by providers who do not take the preference survey, but who identify preferences that are close enough to their own in the settings menu for the precision feedback system.
+Preferences for precision feedback are elicited through a preference survey that providers can take. The preference survey produces a preference model for each provider that, with the provider's permission, is shared with MPOG to maintain. MPOG analyses preference data that is shared to identify population-level preference segments. These segments are generated as preference profiles that can serve as a default preference model for an organization, or which can be selected by providers who do not take the preference survey, but who identify preferences that are close enough to their own in the settings menu for the precision feedback system.
 
 Deepa's preference data:
 

--- a/vignettes/worsening_vignette/readme.md
+++ b/vignettes/worsening_vignette/readme.md
@@ -34,7 +34,7 @@ Gaile, a resident anesthesiologist at Midwest Medicine, has the following perfor
 |Mar  |              93%|               96|          91|
 
 ## Preference data
-Preferences for precision feedback are elicited through a preference survey that providers can take. The preference survey produces a preference model for each provider that, with the provider's permission, is shared with MPOG to maintain. MPOG analyses preferences data that is shared to identify population-level preference segments. This generates preference profiles that can serve as a default preference model for an organization, or which can be selected by providers who do not take the preference survey, but who identify preferences that are close enough to their own in the settings menu for the precision feedback system.
+Preferences for precision feedback are elicited through a preference survey that providers can take. The preference survey produces a preference model for each provider that, with the provider's permission, is shared with MPOG to maintain. MPOG analyses preference data that is shared to identify population-level preference segments. These segments are generated as preference profiles that can serve as a default preference model for an organization, or which can be selected by providers who do not take the preference survey, but who identify preferences that are close enough to their own in the settings menu for the precision feedback system.
 
 Fahad's preference data:
 


### PR DESCRIPTION
Added standard wording for preferences introduction 6/6, propagating out from social loss to all completed vignettes