### PR TITLE
Performance Data Comparator Patch

### DIFF
--- a/vignettes/goal_approach_vignette/readme.md
+++ b/vignettes/goal_approach_vignette/readme.md
@@ -15,24 +15,24 @@ MPOG calculates performance benchmarks and averages for each institution. One co
 Alice, an attending anesthesiologist at Midwest Medicine, has the following performance data over the last 6 months for GLU-03:
 
 |Month|Performance Level|Peer Average|75th Percentile Benchmark|90th Percentile Benchmark|MPOG Goal|
-|-----|-----------------|------------|-------------------------|-------------------------|-----|
-|Jul  |              90%|          90|                       92|                       96|   90|
-|Aug  |              90%|          90|                       92|                       96|   90|
-|Sept |              90%|          90|                       92|                       96|   90|
-|Oct  |              90%|          90|                       92|                       96|   90|
-|Nov  |          **90%**|          90|                       92|                       96|   90|
-|Dec  |          **91%**|          90|                       92|                       96|   90|
+|-----|---------|---|---|---|---|
+|Jul  |      85%| 90| 92| 96| 90|
+|Aug  |      85%| 90| 92| 96| 90|
+|Sept |      85%| 90| 92| 96| 90|
+|Oct  |      85%| 90| 92| 96| 90|
+|Nov  |***87%***| 90| 92| 96| 90|
+|Dec  |***89%***| 90| 92| 96| 90|
 
 Chikondi, a resident anesthesiologist at Max Community Hospital, has the following performance data over the last 6 months for GLU-03:
 
 |Month|Performance Level|Peer Average|75th Percentile Benchmark|90th Percentile Benchmark|MPOG Goal|
-|-----|-----------------|------------|-------------------------|-------------------------|-----|
-|Jul  |              85%|          85|                       88|                       92|   90|
-|Aug  |              85%|          85|                       88|                       92|   90|
-|Sept |              85%|          85|                       88|                       92|   90|
-|Oct  |              85%|          85|                       88|                       92|   90|
-|Nov  |          **85%**|          85|                       88|                       92|   90|
-|Dec  |          **87%**|          85|                       88|                       92|   90|
+|-----|---------|---|---|---|---|
+|Jul  |      82%| 85| 88| 92| 90|
+|Aug  |      82%| 85| 88| 92| 90|
+|Sept |      82%| 85| 88| 92| 90|
+|Oct  |      82%| 85| 88| 92| 90|
+|Nov  |***85%***| 85| 88| 92| 90|
+|Dec  |***87%***| 85| 88| 92| 90|
 
 ## Preference data
 Preferences for precision feedback are elicited through a preference survey that providers can take. The preference survey produces a preference model for each provider that, with the provider's permission, is shared with MPOG to maintain. MPOG analyses preference data that is shared to identify population-level preference segments. These segments are generated as preference profiles that can serve as a default preference model for an organization, or which can be selected by providers who do not take the preference survey, but who identify preferences that are close enough to their own in the settings menu for the precision feedback system.

--- a/vignettes/goal_gain_vignette/readme.md
+++ b/vignettes/goal_gain_vignette/readme.md
@@ -14,8 +14,8 @@ Eugene ... Todo
 |Aug  |      85%| 85| 88| 92| 90|
 |Sept |      85%| 85| 88| 92| 90|
 |Oct  |      85%| 85| 88| 92| 90|
-|Nov  |***xx%***| 85| 88| 92| 90|
-|Dec  |***xx%***| 85| 88| 92| 90|
+|Nov  |***85%***| 85| 88| 92| 90|
+|Dec  |***91%***| 85| 88| 92| 90|
 
 Gaile ... Todo
 |Month|Performance Level|Peer Average|75th Percentile Benchmark|90th Percentile Benchmark|MPOG Goal|
@@ -24,8 +24,8 @@ Gaile ... Todo
 |Aug  |      85%| 85| 88| 92| 90|
 |Sept |      85%| 85| 88| 92| 90|
 |Oct  |      85%| 85| 88| 92| 90|
-|Nov  |***xx%***| 85| 88| 92| 90|
-|Dec  |***xx%***| 85| 88| 92| 90|
+|Nov  |***88%***| 85| 88| 92| 90|
+|Dec  |***95%***| 85| 88| 92| 90|
 
 ### Benchmark comparators
 Alice's peer benchmarks for last month are 93% for the top 25% peer benchmark (75th percentile http://purl.obolibrary.org/obo/psdo_0000128), and 96% for the top 10% peer benchmark (90th percentile http://purl.obolibrary.org/obo/psdo_0000129).

--- a/vignettes/improving_vignette/readme.md
+++ b/vignettes/improving_vignette/readme.md
@@ -13,24 +13,24 @@ Deepa's performance rate for BP-03 has level of 85% for November 2023, 86% for D
 Deepa, a dedicated Certified Registered Nurse Anesthetist (CRNA) at Midwest Medicine, has the following performance data over the last 6 months for BP-03:
 
 |Month|Performance Level|Peer Average|75th Percentile Benchmark|90th Percentile Benchmark|MPOG Goal|
-|-----|-----------------|------------|-------------------------|-------------------------|--|
-|Jul  |              80%|          80|                       85|                       90|90|
-|Aug  |              80%|          80|                       85|                       90|90|
-|Sept |              80%|          80|                       85|                       90|90|
-|Oct  |              80%|          80|                       85|                       90|90|
-|Nov  |          **82%**|          80|                       85|                       90|90|
-|Dec  |          **84%**|          80|                       85|                       90|90|
+|-----|---------|---|---|---|---|
+|Jul  |      75%| 80| 85| 90| 90|
+|Aug  |      75%| 80| 85| 90| 90|
+|Sept |      75%| 80| 85| 90| 90|
+|Oct  |      75%| 80| 85| 90| 90|
+|Nov  |***78%***| 80| 85| 90| 90|
+|Dec  |***87%***| 80| 85| 90| 90|
 
 Gaile, a resident at Midwest Medicine, has the following performance data over the last 6 months for BP-03:
 
 |Month|Performance Level|Peer Average|75th Percentile Benchmark|90th Percentile Benchmark|MPOG Goal|
-|-----|-----------------|------------|-------------------------|-------------------------|--|
-|Jul  |              85%|          85|                       88|                       92|90|
-|Aug  |              85%|          85|                       88|                       92|90|
-|Sept |              85%|          85|                       88|                       92|90|
-|Oct  |              85%|          85|                       88|                       92|90|
-|Nov  |          **87%**|          85|                       88|                       92|90|
-|Dec  |          **90%**|          85|                       88|                       92|90|
+|-----|---------|---|---|---|---|
+|Jul  |      85%| 85| 88| 92| 90|
+|Aug  |      85%| 85| 88| 92| 90|
+|Sept |      85%| 85| 88| 92| 90|
+|Oct  |      85%| 85| 88| 92| 90|
+|Nov  |***87%***| 85| 88| 92| 90|
+|Dec  |***90%***| 85| 88| 92| 90|
 
 ## Preference data
 Preferences for precision feedback are elicited through a preference survey that providers can take. The preference survey produces a preference model for each provider that, with the provider's permission, is shared with MPOG to maintain. MPOG analyses preference data that is shared to identify population-level preference segments. These segments are generated as preference profiles that can serve as a default preference model for an organization, or which can be selected by providers who do not take the preference survey, but who identify preferences that are close enough to their own in the settings menu for the precision feedback system.

--- a/vignettes/improving_vignette/readme.md
+++ b/vignettes/improving_vignette/readme.md
@@ -18,7 +18,7 @@ Deepa, a dedicated Certified Registered Nurse Anesthetist (CRNA) at Midwest Medi
 |Aug  |      75%| 80| 85| 90| 90|
 |Sept |      75%| 80| 85| 90| 90|
 |Oct  |      75%| 80| 85| 90| 90|
-|Nov  |***78%***| 80| 85| 90| 90|
+|Nov  |***82%***| 80| 85| 90| 90|
 |Dec  |***87%***| 80| 85| 90| 90|
 
 Gaile, a resident at Midwest Medicine, has the following performance data over the last 6 months for BP-03:

--- a/vignettes/social_approach_vignette/readme.md
+++ b/vignettes/social_approach_vignette/readme.md
@@ -14,24 +14,24 @@ MPOG calculates performance benchmarks and averages for each institution. One co
 Bob, a nurse anesthetist (CRNA) at Max Commuity Hospital, has the following performance data over the last 6 months for the FLUID-01-NC measure:
 
 |Month|Performance Level|Peer Average|75th Percentile Benchmark|90th Percentile Benchmark|MPOG Goal|
-|-----|-----------------|------------|-------------------------|-------------------------|--|
-|Jul  |              80%|          80|                       85|                       90|--|
-|Aug  |              80%|          80|                       85|                       90|--|
-|Sept |              80%|          80|                       85|                       90|--|
-|Oct  |              80%|          80|                       85|                       90|--|
-|Nov  |          **84%**|          80|                       85|                       90|--|
-|Dec  |          **84%**|          80|                       85|                       90|--|
+|-----|---------|---|---|---|---|
+|Jul  |      75%| 80| 85| 90| 90|
+|Aug  |      75%| 80| 85| 90| 90|
+|Sept |      75%| 80| 85| 90| 90|
+|Oct  |      75%| 80| 85| 90| 90|
+|Nov  |***78%***| 80| 85| 90| 90|
+|Dec  |***84%***| 80| 85| 90| 90|
 
 Deepa, another CRNA at Midwest Medicine, a medical-school affiliated hospital, has the following performance data over the last 6 months for the FLUID-01-NC measure:
 
 |Month|Performance Level|Peer Average|75th Percentile Benchmark|90th Percentile Benchmark|MPOG Goal|
-|-----|-----------------|------------|-------------------------|-------------------------|-|
-|Jul  |              80%|          80|                       85|                       90|--|
-|Aug  |              80%|          80|                       85|                       90|--|
-|Sept |              80%|          80|                       85|                       90|--|
-|Oct  |              80%|          80|                       85|                       90|--|
-|Nov  |          **85%**|          80|                       85|                       90|--|
-|Dec  |          **88%**|          80|                       85|                       90|--|
+|-----|---------|---|---|---|---|
+|Jul  |      95%| 80| 85| 90| 90|
+|Aug  |      95%| 80| 85| 90| 90|
+|Sept |      95%| 80| 85| 90| 90|
+|Oct  |      95%| 80| 85| 90| 90|
+|Nov  |***84%***| 80| 85| 90| 90|
+|Dec  |***89%***| 80| 85| 90| 90|
 
 ## Preference data
 Preferences for precision feedback are elicited through a preference survey that providers can take. The preference survey produces a preference model for each provider that, with the provider's permission, is shared with MPOG to maintain. MPOG analyses preference data that is shared to identify population-level preference segments. These segments are generated as preference profiles that can serve as a default preference model for an organization, or which can be selected by providers who do not take the preference survey, but who identify preferences that are close enough to their own in the settings menu for the precision feedback system.

--- a/vignettes/social_worse_vignette/readme.md
+++ b/vignettes/social_worse_vignette/readme.md
@@ -15,24 +15,24 @@ MPOG calculates performance benchmarks and averages for each institution. One co
 Deepa, a nurse anesthetist (CRNA) at Midwest Medicine, has the following performance data over the last 6 months for the GLU-01 measure:
 
 |Month|Performance Level|Peer Average|75th Percentile Benchmark|90th Percentile Benchmark|MPOG Goal|
-|-----|-----------------|------------|-------------------------|-------------------------|-|
-|Jul  |              80%|          80|                       85|                       90|90|
-|Aug  |              80%|          80|                       85|                       90|90|
-|Sept |              80%|          80|                       85|                       90|90|
-|Oct  |              80%|          80|                       85|                       90|90|
-|Nov  |          **88%**|          80|                       85|                       90|90|
-|Dec  |          **89%**|          80|                       85|                       90|90|
+|-----|---------|---|---|---|---|
+|Jul  |      95%| 80| 85| 90| 90|
+|Aug  |      95%| 80| 85| 90| 90|
+|Sept |      95%| 80| 85| 90| 90|
+|Oct  |      95%| 80| 85| 90| 90|
+|Nov  |***95%***| 80| 85| 90| 90|
+|Dec  |***89%***| 80| 85| 90| 90|
 
 Eugene, a resident anesthesiologist at Midwest Medicine, has the following performance data over the last 6 months for the GLU-01 measure:
 
 |Month|Performance Level|Peer Average|75th Percentile Benchmark|90th Percentile Benchmark|MPOG Goal|
-|-----|-----------------|------------|-------------------------|-------------------------|--|
-|Jul  |              85%|          85|                       88|                       92|90|
-|Aug  |              85%|          85|                       88|                       92|90|
-|Sept |              85%|          85|                       88|                       92|90|
-|Oct  |              85%|          85|                       88|                       92|90|
-|Nov  |          **90%**|          85|                       88|                       92|90|
-|Dec  |          **90%**|          85|                       88|                       92|90|
+|-----|---------|---|---|---|---|
+|Jul  |      80%| 85| 88| 92| 90|
+|Aug  |      80%| 85| 88| 92| 90|
+|Sept |      80%| 85| 88| 92| 90|
+|Oct  |      80%| 85| 88| 92| 90|
+|Nov  |***80%***| 85| 88| 92| 90|
+|Dec  |***87%***| 85| 88| 92| 90|
 
 ## Preference data
 Preferences for precision feedback are elicited through a preference survey that providers can take. The preference survey produces a preference model for each provider that, with the provider's permission, is shared with MPOG to maintain. MPOG analyses preference data that is shared to identify population-level preference segments. These segments are generated as preference profiles that can serve as a default preference model for an organization, or which can be selected by providers who do not take the preference survey, but who identify preferences that are close enough to their own in the settings menu for the precision feedback system.

--- a/vignettes/social_worse_vignette/readme.md
+++ b/vignettes/social_worse_vignette/readme.md
@@ -32,7 +32,7 @@ Eugene, a resident anesthesiologist at Midwest Medicine, has the following perfo
 |Sept |      80%| 85| 88| 92| 90|
 |Oct  |      80%| 85| 88| 92| 90|
 |Nov  |***80%***| 85| 88| 92| 90|
-|Dec  |***87%***| 85| 88| 92| 90|
+|Dec  |***84%***| 85| 88| 92| 90|
 
 ## Preference data
 Preferences for precision feedback are elicited through a preference survey that providers can take. The preference survey produces a preference model for each provider that, with the provider's permission, is shared with MPOG to maintain. MPOG analyses preference data that is shared to identify population-level preference segments. These segments are generated as preference profiles that can serve as a default preference model for an organization, or which can be selected by providers who do not take the preference survey, but who identify preferences that are close enough to their own in the settings menu for the precision feedback system.

--- a/vignettes/worsening_vignette/readme.md
+++ b/vignettes/worsening_vignette/readme.md
@@ -14,25 +14,24 @@ MPOG calculates performance benchmarks and averages for each institution. One co
 Fahad, an attending anesthesiologist at Max Community Hospital, has the following performance data over the last 6 months for the SUS-04 measure:
 
 |Month|Performance Level|Peer Average|75th Percentile Benchmark|90th Percentile Benchmark|MPOG Goal|
-|-----|-----------------|------------|-------------------------|-------------------------|-|
-|Jul  |              90%|          90|                       92|                       96|90|
-|Aug  |              90%|          90|                       92|                       96|90|
-|Sept |              90%|          90|                       92|                       96|90|
-|Oct  |              90%|          90|                       92|                       96|90|
-|Nov  |          ***97%***|          90|                       92|                       96|90|
-|Dec  |          ***93%***|          90|                       92|                       96|90|
+|-----|---------|---|---|---|---|
+|Jul  |      98%| 90| 92| 96| 90|
+|Aug  |      98%| 90| 92| 96| 90|
+|Sept |      98%| 90| 92| 96| 90|
+|Oct  |      98%| 90| 92| 96| 90|
+|Nov  |***98%***| 90| 92| 96| 90|
+|Dec  |***93%***| 90| 92| 96| 90|
 
 Gaile, a resident anesthesiologist at Midwest Medicine, has the following performance data over the last 6 months for the SUS-02 measure:
 
 |Month|Performance Level|Peer Average|75th Percentile Benchmark|90th Percentile Benchmark|MPOG Goal|
-|-----|-----------------|------------|-------------------------|-------------------------|-|
-|Jul  |              85%|          85|                       88|                       92|90|
-|Aug  |              85%|          85|                       88|                       92|90|
-|Sept |              85%|          85|                       88|                       92|90|
-|Oct  |              85%|          85|                       88|                       92|90|
-|Nov  |          ***90%***|          85|                       88|                       92|90|
-|Dec  |          ***86%***|          85|                       88|                       92|90|
-
+|-----|---------|---|---|---|---|
+|Jul  |      88%| 85| 88| 92| 90|
+|Aug  |      88%| 85| 88| 92| 90|
+|Sept |      88%| 85| 88| 92| 90|
+|Oct  |      88%| 85| 88| 92| 90|
+|Nov  |***86%***| 85| 88| 92| 90|
+|Dec  |***80%***| 85| 88| 92| 90|
 
 ## Preference data
 Preferences for precision feedback are elicited through a preference survey that providers can take. The preference survey produces a preference model for each provider that, with the provider's permission, is shared with MPOG to maintain. MPOG analyses preference data that is shared to identify population-level preference segments. These segments are generated as preference profiles that can serve as a default preference model for an organization, or which can be selected by providers who do not take the preference survey, but who identify preferences that are close enough to their own in the settings menu for the precision feedback system.


### PR DESCRIPTION
Editing vignettes performance data with input from team meeting on 6/20/23.
- Listing rationale for changes in commit notes, persona spec sheet, and meeting agenda
- Changing past performance data as well as the most recent two months
- Updating tracker as appropriate
- Updating [persona specification sheet](https://docs.google.com/spreadsheets/d/1ZxtuEPI5EVfnO-YcvzGjbUSy3woixCsaz4slOCozVEU/edit#gid=0) with yellow comparator columns showing logic for the edits in this patch